### PR TITLE
Changing the published status of news and field storage modifications

### DIFF
--- a/config/uregni/config/core.base_field_override.node.news.status.yml
+++ b/config/uregni/config/core.base_field_override.node.news.status.yml
@@ -1,0 +1,22 @@
+uuid: 8ba04d6f-3694-4357-aa9c-cea467923660
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.news
+id: node.news.status
+field_name: status
+entity_type: node
+bundle: news
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/uregni/config/field.storage.node.body.yml
+++ b/config/uregni/config/field.storage.node.body.yml
@@ -1,5 +1,5 @@
 uuid: 576c5bf2-071a-4f61-9b17-59ce1ef8c520
-langcode: en
+langcode: und
 status: true
 dependencies:
   module:

--- a/config/uregni/config/field.storage.node.field_photo.yml
+++ b/config/uregni/config/field.storage.node.field_photo.yml
@@ -1,5 +1,5 @@
 uuid: 4b1760d7-a218-4ef9-8780-1274c432e9b9
-langcode: en
+langcode: und
 status: true
 dependencies:
   module:
@@ -13,13 +13,9 @@ field_name: field_photo
 entity_type: node
 type: image
 settings:
-  uri_scheme: public
   default_image:
     uuid: ''
-    alt: ''
-    title: ''
-    width: null
-    height: null
+  uri_scheme: public
   target_type: file
   display_field: false
   display_default: false

--- a/config/uregni/config/field.storage.node.field_published_date.yml
+++ b/config/uregni/config/field.storage.node.field_published_date.yml
@@ -1,5 +1,5 @@
 uuid: f8b54734-6816-4eac-83db-0cb27f62179f
-langcode: en
+langcode: und
 status: true
 dependencies:
   module:


### PR DESCRIPTION
Not entirely sure why the langcode is changing in the field.storage yml files. Seems to change after a migration. 