### PR TITLE
Adding metatag and pathauto settings for News/Publications/Consultations

### DIFF
--- a/config/uregni/config/core.entity_form_display.node.consultation.default.yml
+++ b/config/uregni/config/core.entity_form_display.node.consultation.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.consultation.field_attachment
     - field.field.node.consultation.field_consultation_dates
     - field.field.node.consultation.field_email_address
+    - field.field.node.consultation.field_meta_tags
     - field.field.node.consultation.field_postal
     - field.field.node.consultation.field_publication_topic
     - field.field.node.consultation.field_published_date
@@ -15,9 +16,9 @@ dependencies:
   module:
     - address
     - datetime
-    - datetime_range
     - field_group
     - file
+    - metatag
     - path
     - text
 third_party_settings:
@@ -44,8 +45,8 @@ bundle: consultation
 mode: default
 content:
   body:
+    weight: 7
     type: text_textarea_with_summary
-    weight: 11
     settings:
       rows: 9
       summary_rows: 3
@@ -60,25 +61,32 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_attachment:
-    weight: 12
+    weight: 8
+    type: file_generic
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
-    type: file_generic
     region: content
   field_consultation_dates:
-    weight: 9
+    weight: 5
+    type: datetime_default
     settings: {  }
     third_party_settings: {  }
-    type: daterange_default
     region: content
   field_email_address:
-    weight: 14
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
+    weight: 10
     type: email_default
+    settings:
+      placeholder: ''
+      size: 60
+    third_party_settings: {  }
+    region: content
+  field_meta_tags:
+    weight: 51
+    settings:
+      sidebar: true
+    third_party_settings: {  }
+    type: metatag_firehose
     region: content
   field_postal:
     weight: 15
@@ -87,16 +95,16 @@ content:
     type: address_default
     region: content
   field_publication_topic:
+    weight: 3
     type: options_select
-    weight: 7
+    settings: {  }
+    third_party_settings: {  }
     region: content
-    settings: {  }
-    third_party_settings: {  }
   field_published_date:
-    weight: 8
+    weight: 4
+    type: datetime_default
     settings: {  }
     third_party_settings: {  }
-    type: datetime_default
     region: content
   field_summary:
     weight: 10
@@ -150,5 +158,10 @@ content:
       placeholder: ''
       match_limit: 10
     region: content
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden: {  }

--- a/config/uregni/config/core.entity_form_display.node.news.default.yml
+++ b/config/uregni/config/core.entity_form_display.node.news.default.yml
@@ -4,14 +4,15 @@ status: true
 dependencies:
   config:
     - field.field.node.news.body
+    - field.field.node.news.field_meta_tags
     - field.field.node.news.field_photo
     - field.field.node.news.field_published_date
     - field.field.node.news.field_teaser
-    - image.style.thumbnail
     - node.type.news
   module:
     - datetime
-    - image
+    - file
+    - metatag
     - path
     - text
 _core:
@@ -22,12 +23,12 @@ bundle: news
 mode: default
 content:
   body:
+    weight: 7
     type: text_textarea_with_summary
-    weight: 10
     settings:
       rows: 9
-      placeholder: ''
       summary_rows: 3
+      placeholder: ''
       show_summary: false
     third_party_settings: {  }
     region: content
@@ -37,19 +38,25 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_meta_tags:
+    weight: 51
+    settings:
+      sidebar: true
+    third_party_settings: {  }
+    type: metatag_firehose
+    region: content
   field_photo:
-    weight: 9
+    weight: 6
+    type: file_generic
     settings:
       progress_indicator: throbber
-      preview_image_style: thumbnail
     third_party_settings: {  }
-    type: image_image
     region: content
   field_published_date:
-    weight: 7
+    weight: 4
+    type: datetime_default
     settings: {  }
     third_party_settings: {  }
-    type: datetime_default
     region: content
   field_teaser:
     weight: 8
@@ -103,5 +110,10 @@ content:
       placeholder: ''
       match_limit: 10
     region: content
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden: {  }

--- a/config/uregni/config/core.entity_form_display.node.publication_page.default.yml
+++ b/config/uregni/config/core.entity_form_display.node.publication_page.default.yml
@@ -4,15 +4,16 @@ status: true
 dependencies:
   config:
     - field.field.node.publication_page.body
+    - field.field.node.publication_page.field_meta_tags
     - field.field.node.publication_page.field_publication_date
     - field.field.node.publication_page.field_publication_image
     - field.field.node.publication_page.field_publication_topic
     - field.field.node.publication_page.field_publication_type
-    - image.style.thumbnail
     - node.type.publication_page
   module:
     - datetime
-    - image
+    - file
+    - metatag
     - path
     - text
 id: node.publication_page.default
@@ -21,8 +22,8 @@ bundle: publication_page
 mode: default
 content:
   body:
+    weight: 5
     type: text_textarea_with_summary
-    weight: 10
     settings:
       rows: 9
       summary_rows: 3
@@ -36,36 +37,38 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_publication_date:
-    type: datetime_default
-    weight: 9
+  field_meta_tags:
+    weight: 51
+    settings:
+      sidebar: true
+    third_party_settings: {  }
+    type: metatag_firehose
     region: content
+  field_publication_date:
+    weight: 4
+    type: datetime_default
     settings: {  }
     third_party_settings: {  }
-  field_publication_image:
-    type: image_image
-    weight: 11
     region: content
+  field_publication_image:
+    weight: 6
+    type: file_generic
     settings:
       progress_indicator: throbber
-      preview_image_style: thumbnail
     third_party_settings: {  }
+    region: content
   field_publication_topic:
-    type: entity_reference_autocomplete
-    weight: 8
-    region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_publication_type:
+    weight: 3
     type: options_select
-    weight: 7
-    region: content
     settings: {  }
     third_party_settings: {  }
+    region: content
+  field_publication_type:
+    weight: 3
+    type: options_select
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   path:
     type: path
     weight: 5
@@ -110,5 +113,10 @@ content:
       placeholder: ''
       match_limit: 10
     region: content
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden: {  }

--- a/config/uregni/config/core.entity_view_display.node.consultation.default.yml
+++ b/config/uregni/config/core.entity_view_display.node.consultation.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.consultation.field_attachment
     - field.field.node.consultation.field_consultation_dates
     - field.field.node.consultation.field_email_address
+    - field.field.node.consultation.field_meta_tags
     - field.field.node.consultation.field_postal
     - field.field.node.consultation.field_publication_topic
     - field.field.node.consultation.field_published_date
@@ -87,4 +88,5 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_meta_tags: true
   field_publication_topic: true

--- a/config/uregni/config/core.entity_view_display.node.consultation.teaser.yml
+++ b/config/uregni/config/core.entity_view_display.node.consultation.teaser.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.consultation.field_attachment
     - field.field.node.consultation.field_consultation_dates
     - field.field.node.consultation.field_email_address
+    - field.field.node.consultation.field_meta_tags
     - field.field.node.consultation.field_postal
     - field.field.node.consultation.field_publication_topic
     - field.field.node.consultation.field_published_date
@@ -40,6 +41,7 @@ hidden:
   field_attachment: true
   field_consultation_dates: true
   field_email_address: true
+  field_meta_tags: true
   field_postal: true
   field_publication_topic: true
   field_published_date: true

--- a/config/uregni/config/core.entity_view_display.node.news.default.yml
+++ b/config/uregni/config/core.entity_view_display.node.news.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.news.body
+    - field.field.node.news.field_meta_tags
     - field.field.node.news.field_photo
     - field.field.node.news.field_published_date
     - field.field.node.news.field_teaser
@@ -52,4 +53,5 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_meta_tags: true
   field_teaser: true

--- a/config/uregni/config/core.entity_view_display.node.news.teaser.yml
+++ b/config/uregni/config/core.entity_view_display.node.news.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.news.body
+    - field.field.node.news.field_meta_tags
     - field.field.node.news.field_photo
     - field.field.node.news.field_published_date
     - field.field.node.news.field_teaser
@@ -33,6 +34,7 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  field_meta_tags: true
   field_photo: true
   field_published_date: true
   field_teaser: true

--- a/config/uregni/config/core.entity_view_display.node.publication_page.default.yml
+++ b/config/uregni/config/core.entity_view_display.node.publication_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.publication_page.body
+    - field.field.node.publication_page.field_meta_tags
     - field.field.node.publication_page.field_publication_date
     - field.field.node.publication_page.field_publication_image
     - field.field.node.publication_page.field_publication_topic
@@ -51,5 +52,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_meta_tags: true
   field_publication_topic: true
   field_publication_type: true

--- a/config/uregni/config/core.entity_view_display.node.publication_page.teaser.yml
+++ b/config/uregni/config/core.entity_view_display.node.publication_page.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.publication_page.body
+    - field.field.node.publication_page.field_meta_tags
     - field.field.node.publication_page.field_publication_date
     - field.field.node.publication_page.field_publication_image
     - field.field.node.publication_page.field_publication_topic
@@ -32,6 +33,7 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  field_meta_tags: true
   field_publication_date: true
   field_publication_image: true
   field_publication_topic: true

--- a/config/uregni/config/field.field.node.consultation.field_meta_tags.yml
+++ b/config/uregni/config/field.field.node.consultation.field_meta_tags.yml
@@ -1,0 +1,21 @@
+uuid: 6322d6ee-0132-48e1-aa5b-a575c28a6616
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.consultation
+  module:
+    - metatag
+id: node.consultation.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: consultation
+label: 'Meta tags'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/config/uregni/config/field.field.node.news.field_meta_tags.yml
+++ b/config/uregni/config/field.field.node.news.field_meta_tags.yml
@@ -1,0 +1,21 @@
+uuid: 5116ba96-7a03-4700-9ec4-6084df62cd34
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.news
+  module:
+    - metatag
+id: node.news.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: news
+label: 'Meta tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/config/uregni/config/field.field.node.publication_page.field_meta_tags.yml
+++ b/config/uregni/config/field.field.node.publication_page.field_meta_tags.yml
@@ -1,0 +1,21 @@
+uuid: b9ad5b9d-98e4-4deb-a70c-a1a5094807bf
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.publication_page
+  module:
+    - metatag
+id: node.publication_page.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: publication_page
+label: 'Meta tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/config/uregni/config/field.storage.node.field_meta_tags.yml
+++ b/config/uregni/config/field.storage.node.field_meta_tags.yml
@@ -1,0 +1,19 @@
+uuid: 8d6ca006-32a5-471b-a3ec-22bc413efc77
+langcode: en
+status: true
+dependencies:
+  module:
+    - metatag
+    - node
+id: node.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+type: metatag
+settings: {  }
+module: metatag
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/uregni/config/pathauto.pattern.consultations_pattern.yml
+++ b/config/uregni/config/pathauto.pattern.consultations_pattern.yml
@@ -1,0 +1,22 @@
+uuid: d6eeca41-05c6-49b4-aeea-44cfc7980d80
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: consultations_pattern
+label: 'Consultations pattern'
+type: 'canonical_entities:node'
+pattern: 'consultations/[node:title]'
+selection_criteria:
+  f20bb793-aee9-48fc-a7a2-4973b85fc403:
+    id: node_type
+    bundles:
+      consultation: consultation
+    negate: false
+    context_mapping:
+      node: node
+    uuid: f20bb793-aee9-48fc-a7a2-4973b85fc403
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/config/uregni/config/pathauto.pattern.news_pattern.yml
+++ b/config/uregni/config/pathauto.pattern.news_pattern.yml
@@ -1,0 +1,22 @@
+uuid: 38f8b59f-3f06-41a5-8a85-1afeae7d7cdb
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: news_pattern
+label: 'News pattern'
+type: 'canonical_entities:node'
+pattern: 'news-centre/[node:title]'
+selection_criteria:
+  fe8cccf9-a189-4299-8cb1-9f6dcd7715de:
+    id: node_type
+    bundles:
+      news: news
+    negate: false
+    context_mapping:
+      node: node
+    uuid: fe8cccf9-a189-4299-8cb1-9f6dcd7715de
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/config/uregni/config/pathauto.pattern.publications_pattern.yml
+++ b/config/uregni/config/pathauto.pattern.publications_pattern.yml
@@ -1,0 +1,22 @@
+uuid: 8d43bfa1-09ac-46f1-a1b6-ff92f7852e24
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: publications_pattern
+label: 'Publications pattern'
+type: 'canonical_entities:node'
+pattern: 'publications/[node:title]'
+selection_criteria:
+  322e59ef-bc1b-4a92-8ab1-4f9c5eb27362:
+    id: node_type
+    bundles:
+      publication_page: publication_page
+    negate: false
+    context_mapping:
+      node: node
+    uuid: 322e59ef-bc1b-4a92-8ab1-4f9c5eb27362
+selection_logic: and
+weight: -5
+relationships: {  }


### PR DESCRIPTION
Tidying the 3 content types I've been working on (News, Publications, Consultations)

- I've added a metatag field and applied it to the 3 content types.
- I've added pathauto patterns for all 3 content types.
- There is a URL redirect field added in from enabling the redirect module in D8UN-redirect-settings