### PR TITLE
D8 un tidy content types

### DIFF
--- a/config/uregni/config/core.entity_form_display.node.consultation.default.yml
+++ b/config/uregni/config/core.entity_form_display.node.consultation.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - node.type.consultation
   module:
     - datetime
+    - datetime_range
     - field_group
     - file
     - metatag
@@ -44,7 +45,7 @@ bundle: consultation
 mode: default
 content:
   body:
-    weight: 7
+    weight: 11
     type: text_textarea_with_summary
     settings:
       rows: 9
@@ -60,15 +61,15 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_attachment:
-    weight: 8
+    weight: 12
     type: file_generic
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
     region: content
   field_consultation_dates:
-    weight: 5
-    type: datetime_default
+    weight: 8
+    type: daterange_default
     settings: {  }
     third_party_settings: {  }
     region: content
@@ -81,7 +82,7 @@ content:
     third_party_settings: {  }
     region: content
   field_meta_tags:
-    weight: 51
+    weight: 15
     settings:
       sidebar: true
     third_party_settings: {  }
@@ -96,28 +97,28 @@ content:
     type: string_textarea
     region: content
   field_publication_topic:
-    weight: 3
+    weight: 4
     type: options_select
     settings: {  }
     third_party_settings: {  }
     region: content
   field_published_date:
-    weight: 4
+    weight: 6
     type: datetime_default
     settings: {  }
     third_party_settings: {  }
     region: content
   field_summary:
-    weight: 10
+    weight: 9
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-    type: text_textarea
+    type: string_textarea
     region: content
   path:
     type: path
-    weight: 5
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -132,14 +133,14 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 6
+    weight: 10
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 4
+    weight: 5
     region: content
     third_party_settings: {  }
   title:
@@ -161,7 +162,7 @@ content:
     region: content
     third_party_settings: {  }
   url_redirects:
-    weight: 50
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/uregni/config/core.entity_form_display.node.news.default.yml
+++ b/config/uregni/config/core.entity_form_display.node.news.default.yml
@@ -8,10 +8,11 @@ dependencies:
     - field.field.node.news.field_photo
     - field.field.node.news.field_published_date
     - field.field.node.news.field_teaser
+    - image.style.thumbnail
     - node.type.news
   module:
     - datetime
-    - file
+    - image
     - metatag
     - path
     - text
@@ -23,7 +24,7 @@ bundle: news
 mode: default
 content:
   body:
-    weight: 7
+    weight: 10
     type: text_textarea_with_summary
     settings:
       rows: 9
@@ -39,27 +40,28 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_meta_tags:
-    weight: 51
+    weight: 12
     settings:
       sidebar: true
     third_party_settings: {  }
     type: metatag_firehose
     region: content
   field_photo:
-    weight: 6
-    type: file_generic
+    weight: 9
+    type: image_image
     settings:
       progress_indicator: throbber
+      preview_image_style: thumbnail
     third_party_settings: {  }
     region: content
   field_published_date:
-    weight: 4
+    weight: 5
     type: datetime_default
     settings: {  }
     third_party_settings: {  }
     region: content
   field_teaser:
-    weight: 8
+    weight: 6
     settings:
       size: 60
       placeholder: ''
@@ -68,7 +70,7 @@ content:
     region: content
   path:
     type: path
-    weight: 5
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -83,7 +85,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 6
+    weight: 8
     region: content
     third_party_settings: {  }
   sticky:
@@ -112,7 +114,7 @@ content:
     region: content
     third_party_settings: {  }
   url_redirects:
-    weight: 50
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/uregni/config/core.entity_view_display.node.consultation.default.yml
+++ b/config/uregni/config/core.entity_view_display.node.consultation.default.yml
@@ -29,12 +29,12 @@ content:
   body:
     label: hidden
     type: text_default
-    weight: 4
+    weight: 3
     settings: {  }
     third_party_settings: {  }
     region: content
   field_attachment:
-    weight: 5
+    weight: 4
     label: above
     settings:
       use_description_as_link_text: true
@@ -42,7 +42,7 @@ content:
     type: file_default
     region: content
   field_consultation_dates:
-    weight: 2
+    weight: 1
     label: hidden
     settings:
       timezone_override: ''
@@ -52,21 +52,21 @@ content:
     type: daterange_default
     region: content
   field_email_address:
-    weight: 6
+    weight: 5
     label: inline
     settings: {  }
     third_party_settings: {  }
     type: email_mailto
     region: content
   field_postal:
-    weight: 7
+    weight: 6
     label: inline
     settings: {  }
     third_party_settings: {  }
     type: basic_string
     region: content
   field_published_date:
-    weight: 1
+    weight: 0
     label: inline
     settings:
       timezone_override: ''
@@ -75,17 +75,13 @@ content:
     type: datetime_default
     region: content
   field_summary:
-    weight: 3
+    weight: 2
     label: above
     settings: {  }
     third_party_settings: {  }
-    type: text_default
+    type: basic_string
     region: content
-  links:
-    weight: 0
-    region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
   field_meta_tags: true
   field_publication_topic: true
+  links: true

--- a/config/uregni/config/core.entity_view_display.node.news.default.yml
+++ b/config/uregni/config/core.entity_view_display.node.news.default.yml
@@ -25,12 +25,12 @@ content:
   body:
     label: hidden
     type: text_default
-    weight: 3
+    weight: 2
     settings: {  }
     third_party_settings: {  }
     region: content
   field_photo:
-    weight: 2
+    weight: 1
     label: hidden
     settings:
       image_style: medium
@@ -39,7 +39,7 @@ content:
     type: image
     region: content
   field_published_date:
-    weight: 1
+    weight: 0
     label: hidden
     settings:
       format_type: medium
@@ -47,11 +47,7 @@ content:
     third_party_settings: {  }
     type: datetime_default
     region: content
-  links:
-    weight: 0
-    region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
   field_meta_tags: true
   field_teaser: true
+  links: true

--- a/config/uregni/config/core.entity_view_display.node.publication_page.default.yml
+++ b/config/uregni/config/core.entity_view_display.node.publication_page.default.yml
@@ -24,13 +24,13 @@ content:
   body:
     label: hidden
     type: text_default
-    weight: 3
+    weight: 2
     settings: {  }
     third_party_settings: {  }
     region: content
   field_publication_date:
     type: datetime_default
-    weight: 1
+    weight: 0
     region: content
     label: hidden
     settings:
@@ -39,19 +39,15 @@ content:
     third_party_settings: {  }
   field_publication_image:
     type: image
-    weight: 2
+    weight: 1
     region: content
     label: hidden
     settings:
       image_style: medium
       image_link: ''
     third_party_settings: {  }
-  links:
-    weight: 0
-    region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
   field_meta_tags: true
   field_publication_topic: true
   field_publication_type: true
+  links: true

--- a/config/uregni/config/field.field.node.consultation.body.yml
+++ b/config/uregni/config/field.field.node.consultation.body.yml
@@ -20,7 +20,7 @@ translatable: true
 default_value:
   -
     summary: ''
-    value: " "
+    value: ' '
     format: filtered_html
 default_value_callback: ''
 settings:

--- a/config/uregni/config/field.field.node.consultation.field_summary.yml
+++ b/config/uregni/config/field.field.node.consultation.field_summary.yml
@@ -1,23 +1,19 @@
-uuid: 9699a9c1-4f39-4669-9b8c-e1db5d278bae
+uuid: 081d2a13-7eb4-49fc-9cad-a5d4dd6914ab
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_summary
     - node.type.consultation
-  module:
-    - text
-_core:
-  default_config_hash: fsl1kzTqbDX8_Xhz1Np3IXh62vRbXi-D_Xb08oQhjXE
 id: node.consultation.field_summary
 field_name: field_summary
 entity_type: node
 bundle: consultation
 label: Summary
-description: 'Enter a summary of this consultation.'
+description: 'Enter a summary for this consultation.'
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: text_long
+field_type: string_long

--- a/config/uregni/config/field.field.node.news.body.yml
+++ b/config/uregni/config/field.field.node.news.body.yml
@@ -20,7 +20,7 @@ translatable: true
 default_value:
   -
     summary: ''
-    value: " "
+    value: ' '
     format: filtered_html
 default_value_callback: ''
 settings:

--- a/config/uregni/config/field.field.node.publication_page.body.yml
+++ b/config/uregni/config/field.field.node.publication_page.body.yml
@@ -18,7 +18,7 @@ translatable: true
 default_value:
   -
     summary: ''
-    value: " "
+    value: ' '
     format: filtered_html
 default_value_callback: ''
 settings:

--- a/config/uregni/config/field.storage.node.field_summary.yml
+++ b/config/uregni/config/field.storage.node.field_summary.yml
@@ -1,18 +1,16 @@
-uuid: e83e3f0b-7430-43cf-930b-e908e4bb28b4
+uuid: 38781943-cb4f-4b68-bea3-85375f74b854
 langcode: en
 status: true
 dependencies:
   module:
     - node
-    - text
-_core:
-  default_config_hash: y3uANBTCu0sinb6ZNRfotIxKa7Gp2E6KTBhia6-i2vE
 id: node.field_summary
 field_name: field_summary
 entity_type: node
-type: text_long
-settings: {  }
-module: text
+type: string_long
+settings:
+  case_sensitive: false
+module: core
 locked: false
 cardinality: 1
 translatable: true


### PR DESCRIPTION
Tidying up content types News/Publications/Consultations after sprint review yesterday

- Changing body yml to use single quotes.

- Changing summary field on consultations to use text plain long to keep in line with D7

- Moving the teaser field in form displays to match D7

- Disabling the links field from view displays.

- Setting consultations to use datetime_range as it should be.