### PR TITLE
Updated basic page config export

### DIFF
--- a/config/uregni/config/core.entity_form_display.node.page.default.yml
+++ b/config/uregni/config/core.entity_form_display.node.page.default.yml
@@ -5,11 +5,13 @@ dependencies:
   config:
     - field.field.node.page.body
     - field.field.node.page.field_enable_toc
+    - field.field.node.page.field_meta_tags
     - field.field.node.page.field_page_top_image
     - image.style.thumbnail
     - node.type.page
   module:
     - image
+    - metatag
     - path
     - text
 id: node.page.default
@@ -39,6 +41,13 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+    region: content
+  field_meta_tags:
+    weight: 51
+    settings:
+      sidebar: true
+    third_party_settings: {  }
+    type: metatag_firehose
     region: content
   field_page_top_image:
     weight: 1
@@ -93,4 +102,9 @@ content:
       match_limit: 10
     region: content
     third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden: {  }

--- a/config/uregni/config/core.entity_view_display.node.page.default.yml
+++ b/config/uregni/config/core.entity_view_display.node.page.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.page.body
     - field.field.node.page.field_enable_toc
+    - field.field.node.page.field_meta_tags
     - field.field.node.page.field_page_top_image
     - node.type.page
   module:
@@ -24,5 +25,6 @@ content:
     region: content
 hidden:
   field_enable_toc: true
+  field_meta_tags: true
   field_page_top_image: true
   links: true

--- a/config/uregni/config/core.entity_view_display.node.page.teaser.yml
+++ b/config/uregni/config/core.entity_view_display.node.page.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.page.body
     - field.field.node.page.field_enable_toc
+    - field.field.node.page.field_meta_tags
     - field.field.node.page.field_page_top_image
     - node.type.page
   module:
@@ -31,4 +32,5 @@ content:
     third_party_settings: {  }
 hidden:
   field_enable_toc: true
+  field_meta_tags: true
   field_page_top_image: true

--- a/config/uregni/config/field.field.node.page.body.yml
+++ b/config/uregni/config/field.field.node.page.body.yml
@@ -18,7 +18,7 @@ translatable: false
 default_value:
   -
     summary: ''
-    value: " "
+    value: ' '
     format: filtered_html
 default_value_callback: ''
 settings:

--- a/config/uregni/config/field.field.node.page.field_meta_tags.yml
+++ b/config/uregni/config/field.field.node.page.field_meta_tags.yml
@@ -1,0 +1,21 @@
+uuid: 63165159-831f-4fd5-8bdd-aff7b655c963
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.page
+  module:
+    - metatag
+id: node.page.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: page
+label: 'Meta tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/config/uregni/config/pathauto.pattern.basic_page_pattern.yml
+++ b/config/uregni/config/pathauto.pattern.basic_page_pattern.yml
@@ -1,0 +1,24 @@
+uuid: 80ed3cea-4e90-45b5-9797-151b6e060ec0
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: basic_page_pattern
+label: 'Basic page pattern'
+type: 'canonical_entities:node'
+pattern: '[node:title]'
+selection_criteria:
+  7bf6f2ea-8059-406a-8239-29c132d37229:
+    id: node_type
+    bundles:
+      page: page
+      vacancy: vacancy
+      webform: webform
+    negate: false
+    context_mapping:
+      node: node
+    uuid: 7bf6f2ea-8059-406a-8239-29c132d37229
+selection_logic: and
+weight: -5
+relationships: {  }


### PR DESCRIPTION
Add meta tag field to basic page content type and add pathauto pattern for basic page (and other content types that have the same 'default' pattern.