### PR TITLE
D8UN-16 Menu config

### DIFF
--- a/config/uregni/config/system.menu.account.yml
+++ b/config/uregni/config/system.menu.account.yml
@@ -5,6 +5,6 @@ dependencies: {  }
 _core:
   default_config_hash: M_Bh81osDyUQ4wV0GgU_NdBNqkzM87sLxjaCdFj9mnw
 id: account
-label: 'User account menu'
-description: 'Links related to the active user account'
+label: 'User menu'
+description: 'The <em>User</em> menu contains links related to the user''s account, as well as the ''Log out'' link.'
 locked: true

--- a/config/uregni/config/system.menu.admin.yml
+++ b/config/uregni/config/system.menu.admin.yml
@@ -5,6 +5,6 @@ dependencies: {  }
 _core:
   default_config_hash: sapEi2YDGoI9yQIT_WgIV2vUdQ6DScH0V3fAyTadAL0
 id: admin
-label: Administration
-description: 'Administrative task links'
+label: Management
+description: 'The <em>Management</em> menu contains links for administrative tasks.'
 locked: true

--- a/config/uregni/config/system.menu.main.yml
+++ b/config/uregni/config/system.menu.main.yml
@@ -5,6 +5,6 @@ dependencies: {  }
 _core:
   default_config_hash: Q2Ra3jfoIVk0f3SjxJX61byRQFVBAbpzYDQOiY-kno8
 id: main
-label: 'Main navigation'
-description: 'Site section links'
+label: 'Main menu'
+description: 'The <em>Main</em> menu is used on many sites to show the major sections of the site, often in a top navigation bar.'
 locked: true

--- a/config/uregni/config/system.menu.menu-footer-links.yml
+++ b/config/uregni/config/system.menu.menu-footer-links.yml
@@ -1,0 +1,8 @@
+uuid: 1370e2a4-9cfe-4b97-8d97-bde0fddf1a9a
+langcode: en
+status: true
+dependencies: {  }
+id: menu-footer-links
+label: 'Footer links'
+description: ''
+locked: false

--- a/config/uregni/config/system.menu.menu-useful-links.yml
+++ b/config/uregni/config/system.menu.menu-useful-links.yml
@@ -1,0 +1,8 @@
+uuid: f2be9a0e-2c07-40f3-ba52-10c0bf4e22b6
+langcode: en
+status: true
+dependencies: {  }
+id: menu-useful-links
+label: 'Useful links'
+description: ''
+locked: false

--- a/config/uregni/config/system.menu.tools.yml
+++ b/config/uregni/config/system.menu.tools.yml
@@ -5,6 +5,6 @@ dependencies: {  }
 _core:
   default_config_hash: BCM-vV1zzRaLHN18dqAR_CuGOj8AFJvTx7BKl_8Gcxc
 id: tools
-label: Tools
-description: 'User tool links, often added by modules'
+label: Navigation
+description: 'The <em>Navigation</em> menu contains links intended for site visitors. Links are added to the <em>Navigation</em> menu automatically by some modules.'
 locked: true


### PR DESCRIPTION
Updates to the site menus following migrate import of upgrade_menu_settings and upgrade_d7_menu. I am unable to delete the footer menu as it is a default menu. 

I can't place the main menu block in the appropriate region yet, as outlined in the Jira task, as the theme has not been set.