### PR TITLE
Taxonomy urls

### DIFF
--- a/config/uregni/config/facets.facet.topic.yml
+++ b/config/uregni/config/facets.facet.topic.yml
@@ -10,14 +10,14 @@ dependencies:
     - search_api
 third_party_settings:
   facets_pretty_paths:
-    coder: default_coder
+    coder: taxonomy_term_coder
 id: topic
 name: Topic
 url_alias: topic
 weight: 0
 min_count: 1
 show_only_one_result: false
-field_identifier: name
+field_identifier: field_publication_topic
 facet_source_id: 'search_api:views_page__publications_search__publication_search_page'
 widget:
   type: links
@@ -44,6 +44,11 @@ processor_configs:
       sort: 40
     settings:
       sort: ASC
+  translate_entity:
+    processor_id: translate_entity
+    weights:
+      build: 5
+    settings: {  }
   url_processor_handler:
     processor_id: url_processor_handler
     weights:

--- a/config/uregni/config/facets.facet.topic_consultation.yml
+++ b/config/uregni/config/facets.facet.topic_consultation.yml
@@ -10,14 +10,14 @@ dependencies:
     - search_api
 third_party_settings:
   facets_pretty_paths:
-    coder: default_coder
+    coder: taxonomy_term_coder
 id: topic_consultation
-name: 'Topic Consultation'
+name: Topic
 url_alias: topic
 weight: 0
 min_count: 1
 show_only_one_result: false
-field_identifier: name
+field_identifier: field_publication_topic
 facet_source_id: 'search_api:views_page__consultations_search__consultations_search_page'
 widget:
   type: links
@@ -44,6 +44,11 @@ processor_configs:
       sort: 40
     settings:
       sort: ASC
+  translate_entity:
+    processor_id: translate_entity
+    weights:
+      build: 5
+    settings: {  }
   url_processor_handler:
     processor_id: url_processor_handler
     weights:

--- a/config/uregni/config/search_api.index.consultations.yml
+++ b/config/uregni/config/search_api.index.consultations.yml
@@ -80,6 +80,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_consultation_dates
+  field_publication_topic:
+    label: Topic
+    datasource_id: 'entity:node'
+    property_path: field_publication_topic
+    type: integer
+    dependencies:
+      config:
+        - field.storage.node.field_publication_topic
   field_published_date:
     label: 'Published date'
     datasource_id: 'entity:node'

--- a/config/uregni/config/search_api.index.publications.yml
+++ b/config/uregni/config/search_api.index.publications.yml
@@ -72,6 +72,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_publication_date
+  field_publication_topic:
+    label: Topic
+    datasource_id: 'entity:node'
+    property_path: field_publication_topic
+    type: integer
+    dependencies:
+      config:
+        - field.storage.node.field_publication_topic
   field_publication_type:
     label: Type
     datasource_id: 'entity:node'

--- a/config/uregni/config/structure_sync.data.yml
+++ b/config/uregni/config/structure_sync.data.yml
@@ -32,7 +32,7 @@ blocks:
     rev_id_current: null
     fields:
       body:
-        value: "<p>Documents about our regulation of water and sewerage services can all be accessed here</p>\r\n\r\n<div class=\"content\">\r\n<p><a class=\"btn\" href=\"publications/topic/Water\">Water Publications</a></p>\r\n</div>\r\n"
+        value: "<p>Documents about our regulation of water and sewerage services can all be accessed here</p>\r\n\r\n<div class=\"content\">\r\n<p><a class=\"btn\" href=\"publications/topic/water-9\">Water Publications</a></p>\r\n</div>\r\n"
         summary: ''
         format: basic_html
   -
@@ -44,7 +44,7 @@ blocks:
     rev_id_current: null
     fields:
       body:
-        value: "<p>As the economic regulator of the gas industry we publish a range of documents about our work</p>\r\n\r\n<p><a class=\"btn\" href=\"publications/topic/Gas/topic/Gas Retail/topic/Gas networks\">Gas Publications</a></p>\r\n"
+        value: "<p>As the economic regulator of the gas industry we publish a range of documents about our work</p>\r\n\r\n<p><a class=\"btn\" href=\"publications/topic/gas-13/topic/gas-networks-7/topic/gas-retail-8\">Gas Publications</a></p>\r\n"
         summary: ''
         format: basic_html
   -
@@ -56,7 +56,7 @@ blocks:
     rev_id_current: null
     fields:
       body:
-        value: "<p><span>We publish a wide range of documents relating to our regulation of the electricity sector</span></p>\r\n\r\n<p><a class=\"btn\" href=\"publications/topic/Electricity/topic/Electricity networks/topic/Electricity retail/topic/Electricity wholesale\">Electricity Publications</a></p>\r\n"
+        value: "<p><span>We publish a wide range of documents relating to our regulation of the electricity sector</span></p>\r\n\r\n<p><a class=\"btn\" href=\"publications/topic/electricity-14/topic/electricity-networks-4/topic/electricity-retail-6/topic/electricity-wholesale-5\">Electricity Publications</a></p>\r\n"
         summary: ''
         format: basic_html
   -

--- a/config/uregni/config/views.view.publications_search.yml
+++ b/config/uregni/config/views.view.publications_search.yml
@@ -266,7 +266,8 @@ display:
       path: publications
       exposed_block: true
       cache:
-        type: none
+        type: search_api_tag
+        options: {  }
       defaults:
         cache: false
       menu:

--- a/config/uregni/config/views.view.publications_search.yml
+++ b/config/uregni/config/views.view.publications_search.yml
@@ -266,8 +266,7 @@ display:
       path: publications
       exposed_block: true
       cache:
-        type: search_api_tag
-        options: {  }
+        type: none
       defaults:
         cache: false
       menu:


### PR DESCRIPTION
- Taxonomy terms selected from the topic facet displayed a taxonomy label. I've added the topic field as an integer to the index and amended the facet to use this field, transforming it to term + id.
- Homepage blocks have a link to the publications topics so I have amended these to use the new term + id path.