### PR TITLE
Changing image fields to an entity reference field

### DIFF
--- a/config/uregni/config/core.entity_form_display.node.news.default.yml
+++ b/config/uregni/config/core.entity_form_display.node.news.default.yml
@@ -7,12 +7,14 @@ dependencies:
     - field.field.node.news.field_meta_tags
     - field.field.node.news.field_photo
     - field.field.node.news.field_published_date
+    - field.field.node.news.field_summary
     - field.field.node.news.field_teaser
-    - image.style.thumbnail
     - node.type.news
+    - workflows.workflow.nics_editorial_workflow
   module:
+    - content_moderation
     - datetime
-    - image
+    - media_library
     - metatag
     - path
     - text
@@ -24,7 +26,7 @@ bundle: news
 mode: default
 content:
   body:
-    weight: 10
+    weight: 11
     type: text_textarea_with_summary
     settings:
       rows: 9
@@ -35,33 +37,32 @@ content:
     region: content
   created:
     type: datetime_timestamp
-    weight: 2
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   field_meta_tags:
-    weight: 12
+    weight: 13
     settings:
       sidebar: true
     third_party_settings: {  }
     type: metatag_firehose
     region: content
   field_photo:
-    weight: 9
-    type: image_image
+    type: media_library_widget
+    weight: 10
     settings:
-      progress_indicator: throbber
-      preview_image_style: thumbnail
+      media_types: {  }
     third_party_settings: {  }
     region: content
   field_published_date:
-    weight: 5
+    weight: 6
     type: datetime_default
     settings: {  }
     third_party_settings: {  }
     region: content
   field_teaser:
-    weight: 6
+    weight: 7
     settings:
       size: 60
       placeholder: ''
@@ -77,13 +78,13 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 100
+    weight: 14
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -91,21 +92,21 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 3
+    weight: 4
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 8
+    weight: 9
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 4
+    weight: 5
     region: content
     third_party_settings: {  }
   title:
@@ -127,8 +128,9 @@ content:
     region: content
     third_party_settings: {  }
   url_redirects:
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_summary: true

--- a/config/uregni/config/core.entity_form_display.node.page.default.yml
+++ b/config/uregni/config/core.entity_form_display.node.page.default.yml
@@ -8,13 +8,12 @@ dependencies:
     - field.field.node.page.field_meta_tags
     - field.field.node.page.field_next_audit_due
     - field.field.node.page.field_page_top_image
-    - image.style.thumbnail
     - node.type.page
     - workflows.workflow.nics_editorial_workflow
   module:
     - content_moderation
     - datetime
-    - image
+    - media_library
     - metatag
     - path
     - text
@@ -24,7 +23,7 @@ bundle: page
 mode: default
 content:
   body:
-    weight: 3
+    weight: 4
     type: text_textarea_with_summary
     settings:
       rows: 9
@@ -35,19 +34,19 @@ content:
     region: content
   created:
     type: datetime_timestamp
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   field_enable_toc:
-    weight: 2
+    weight: 3
     type: boolean_checkbox
     settings:
       display_label: true
     third_party_settings: {  }
     region: content
   field_meta_tags:
-    weight: 51
+    weight: 12
     settings:
       sidebar: true
     third_party_settings: {  }
@@ -55,16 +54,15 @@ content:
     region: content
   field_next_audit_due:
     type: datetime_default
-    weight: 1000
+    weight: 14
     settings: {  }
     third_party_settings: {  }
     region: content
   field_page_top_image:
+    type: media_library_widget
     weight: 1
-    type: image_image
     settings:
-      progress_indicator: throbber
-      preview_image_style: thumbnail
+      media_types: {  }
     third_party_settings: {  }
     region: content
   langcode:
@@ -76,13 +74,13 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 100
+    weight: 13
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -90,21 +88,21 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 6
+    weight: 7
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 9
+    weight: 10
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 7
+    weight: 8
     region: content
     third_party_settings: {  }
   title:
@@ -117,7 +115,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 4
+    weight: 5
     settings:
       match_operator: CONTAINS
       size: 60
@@ -126,8 +124,8 @@ content:
     region: content
     third_party_settings: {  }
   url_redirects:
-    weight: 50
+    weight: 11
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden: {  }

--- a/config/uregni/config/core.entity_form_display.node.publication_page.default.yml
+++ b/config/uregni/config/core.entity_form_display.node.publication_page.default.yml
@@ -9,11 +9,12 @@ dependencies:
     - field.field.node.publication_page.field_publication_image
     - field.field.node.publication_page.field_publication_topic
     - field.field.node.publication_page.field_publication_type
-    - image.style.thumbnail
     - node.type.publication_page
+    - workflows.workflow.nics_editorial_workflow
   module:
+    - content_moderation
     - datetime
-    - image
+    - media_library
     - metatag
     - path
     - text
@@ -52,11 +53,10 @@ content:
     third_party_settings: {  }
     region: content
   field_publication_image:
-    weight: 12
-    type: image_image
+    type: media_library_widget
+    weight: 11
     settings:
-      progress_indicator: throbber
-      preview_image_style: thumbnail
+      media_types: {  }
     third_party_settings: {  }
     region: content
   field_publication_topic:
@@ -78,6 +78,12 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 15
+    settings: {  }
+    region: content
+    third_party_settings: {  }
   path:
     type: path
     weight: 9
@@ -95,7 +101,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 11
+    weight: 12
     region: content
     third_party_settings: {  }
   sticky:

--- a/config/uregni/config/core.entity_form_display.node.staff_member.default.yml
+++ b/config/uregni/config/core.entity_form_display.node.staff_member.default.yml
@@ -7,10 +7,11 @@ dependencies:
     - field.field.node.staff_member.field_member_image
     - field.field.node.staff_member.field_member_role
     - field.field.node.staff_member.field_metatag
-    - image.style.thumbnail
     - node.type.staff_member
+    - workflows.workflow.nics_editorial_workflow
   module:
-    - image
+    - content_moderation
+    - media_library
     - metatag
     - path
     - text
@@ -21,7 +22,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 5
+    weight: 6
     settings:
       rows: 9
       summary_rows: 3
@@ -31,18 +32,17 @@ content:
     region: content
   created:
     type: datetime_timestamp
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   field_member_image:
-    type: image_image
+    type: media_library_widget
     weight: 2
-    region: content
     settings:
-      progress_indicator: throbber
-      preview_image_style: thumbnail
+      media_types: {  }
     third_party_settings: {  }
+    region: content
   field_member_role:
     type: string_textfield
     weight: 1
@@ -53,21 +53,27 @@ content:
     third_party_settings: {  }
   field_metatag:
     type: metatag_firehose
-    weight: 6
+    weight: 7
     region: content
     settings:
       sidebar: true
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 2
+    weight: 3
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 13
+    settings: {  }
+    region: content
+    third_party_settings: {  }
   path:
     type: path
-    weight: 3
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -75,21 +81,21 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 9
+    weight: 10
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 11
+    weight: 12
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 10
+    weight: 11
     region: content
     third_party_settings: {  }
   title:
@@ -102,7 +108,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 7
+    weight: 8
     settings:
       match_operator: CONTAINS
       size: 60
@@ -111,7 +117,7 @@ content:
     region: content
     third_party_settings: {  }
   url_redirects:
-    weight: 4
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/uregni/config/core.entity_form_display.node.vacancy.default.yml
+++ b/config/uregni/config/core.entity_form_display.node.vacancy.default.yml
@@ -80,6 +80,12 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    settings: {  }
+    region: content
+    third_party_settings: {  }
   path:
     type: path
     weight: 5

--- a/config/uregni/config/core.entity_view_display.node.news.default.yml
+++ b/config/uregni/config/core.entity_view_display.node.news.default.yml
@@ -30,10 +30,10 @@ content:
     region: content
   field_photo:
     type: entity_reference_entity_view
-    weight: 3
-    label: above
+    weight: 1
+    label: hidden
     settings:
-      view_mode: default
+      view_mode: landscape_float
       link: false
     third_party_settings: {  }
     region: content

--- a/config/uregni/config/core.entity_view_display.node.news.default.yml
+++ b/config/uregni/config/core.entity_view_display.node.news.default.yml
@@ -7,12 +7,11 @@ dependencies:
     - field.field.node.news.field_meta_tags
     - field.field.node.news.field_photo
     - field.field.node.news.field_published_date
+    - field.field.node.news.field_summary
     - field.field.node.news.field_teaser
-    - image.style.medium
     - node.type.news
   module:
     - datetime
-    - image
     - text
     - user
 _core:
@@ -30,13 +29,13 @@ content:
     third_party_settings: {  }
     region: content
   field_photo:
-    weight: 1
-    label: hidden
+    type: entity_reference_entity_view
+    weight: 3
+    label: above
     settings:
-      image_style: medium
-      image_link: ''
+      view_mode: default
+      link: false
     third_party_settings: {  }
-    type: image
     region: content
   field_published_date:
     weight: 0
@@ -50,6 +49,7 @@ content:
 hidden:
   content_moderation_control: true
   field_meta_tags: true
+  field_summary: true
   field_teaser: true
   langcode: true
   links: true

--- a/config/uregni/config/core.entity_view_display.node.news.teaser.yml
+++ b/config/uregni/config/core.entity_view_display.node.news.teaser.yml
@@ -21,6 +21,15 @@ targetEntityType: node
 bundle: news
 mode: teaser
 content:
+  field_photo:
+    type: entity_reference_entity_view
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
   field_published_date:
     type: datetime_default
     weight: 1
@@ -42,7 +51,6 @@ hidden:
   body: true
   content_moderation_control: true
   field_meta_tags: true
-  field_photo: true
   field_summary: true
   langcode: true
   links: true

--- a/config/uregni/config/core.entity_view_display.node.news.teaser.yml
+++ b/config/uregni/config/core.entity_view_display.node.news.teaser.yml
@@ -10,11 +10,9 @@ dependencies:
     - field.field.node.news.field_published_date
     - field.field.node.news.field_summary
     - field.field.node.news.field_teaser
-    - image.style.nigov_landscape_xxl_960x640_x1
     - node.type.news
   module:
     - datetime
-    - image
     - user
 _core:
   default_config_hash: YM_6LIpbBwjzsujCB_Gzom0QKjA6-UUMc8UhwaqS6_E
@@ -23,15 +21,6 @@ targetEntityType: node
 bundle: news
 mode: teaser
 content:
-  field_photo:
-    type: image
-    weight: 0
-    region: content
-    label: hidden
-    settings:
-      image_style: nigov_landscape_xxl_960x640_x1
-      image_link: content
-    third_party_settings: {  }
   field_published_date:
     type: datetime_default
     weight: 1
@@ -53,6 +42,7 @@ hidden:
   body: true
   content_moderation_control: true
   field_meta_tags: true
+  field_photo: true
   field_summary: true
   langcode: true
   links: true

--- a/config/uregni/config/core.entity_view_display.node.page.default.yml
+++ b/config/uregni/config/core.entity_view_display.node.page.default.yml
@@ -26,10 +26,10 @@ content:
     region: content
   field_page_top_image:
     type: entity_reference_entity_view
-    weight: 2
-    label: above
+    weight: 0
+    label: hidden
     settings:
-      view_mode: default
+      view_mode: landscape_full
       link: false
     third_party_settings: {  }
     region: content

--- a/config/uregni/config/core.entity_view_display.node.page.default.yml
+++ b/config/uregni/config/core.entity_view_display.node.page.default.yml
@@ -10,7 +10,6 @@ dependencies:
     - field.field.node.page.field_page_top_image
     - node.type.page
   module:
-    - image
     - text
     - user
 id: node.page.default
@@ -26,14 +25,14 @@ content:
     third_party_settings: {  }
     region: content
   field_page_top_image:
-    type: image
-    weight: 0
-    region: content
-    label: hidden
+    type: entity_reference_entity_view
+    weight: 2
+    label: above
     settings:
-      image_style: ''
-      image_link: ''
+      view_mode: default
+      link: false
     third_party_settings: {  }
+    region: content
 hidden:
   content_moderation_control: true
   field_enable_toc: true

--- a/config/uregni/config/core.entity_view_display.node.publication_page.default.yml
+++ b/config/uregni/config/core.entity_view_display.node.publication_page.default.yml
@@ -38,9 +38,9 @@ content:
   field_publication_image:
     type: entity_reference_entity_view
     weight: 3
-    label: above
+    label: hidden
     settings:
-      view_mode: default
+      view_mode: landscape_full
       link: false
     third_party_settings: {  }
     region: content

--- a/config/uregni/config/core.entity_view_display.node.publication_page.default.yml
+++ b/config/uregni/config/core.entity_view_display.node.publication_page.default.yml
@@ -9,11 +9,9 @@ dependencies:
     - field.field.node.publication_page.field_publication_image
     - field.field.node.publication_page.field_publication_topic
     - field.field.node.publication_page.field_publication_type
-    - image.style.medium
     - node.type.publication_page
   module:
     - datetime
-    - image
     - text
     - user
 id: node.publication_page.default
@@ -38,14 +36,14 @@ content:
       format_type: uregni_medium
     third_party_settings: {  }
   field_publication_image:
-    type: image
-    weight: 1
-    region: content
-    label: hidden
+    type: entity_reference_entity_view
+    weight: 3
+    label: above
     settings:
-      image_style: medium
-      image_link: ''
+      view_mode: default
+      link: false
     third_party_settings: {  }
+    region: content
 hidden:
   content_moderation_control: true
   field_meta_tags: true

--- a/config/uregni/config/core.entity_view_display.node.staff_member.default.yml
+++ b/config/uregni/config/core.entity_view_display.node.staff_member.default.yml
@@ -25,10 +25,10 @@ content:
     region: content
   field_member_image:
     type: entity_reference_entity_view
-    weight: 3
+    weight: 1
     label: above
     settings:
-      view_mode: default
+      view_mode: portrait_float
       link: false
     third_party_settings: {  }
     region: content

--- a/config/uregni/config/core.entity_view_display.node.staff_member.default.yml
+++ b/config/uregni/config/core.entity_view_display.node.staff_member.default.yml
@@ -9,7 +9,6 @@ dependencies:
     - field.field.node.staff_member.field_metatag
     - node.type.staff_member
   module:
-    - image
     - text
     - user
 id: node.staff_member.default
@@ -25,14 +24,14 @@ content:
     third_party_settings: {  }
     region: content
   field_member_image:
-    type: image
-    weight: 1
-    region: content
-    label: hidden
+    type: entity_reference_entity_view
+    weight: 3
+    label: above
     settings:
-      image_style: ''
-      image_link: ''
+      view_mode: default
+      link: false
     third_party_settings: {  }
+    region: content
   field_member_role:
     type: string
     weight: 0

--- a/config/uregni/config/core.entity_view_display.paragraph.map.default.yml
+++ b/config/uregni/config/core.entity_view_display.paragraph.map.default.yml
@@ -17,7 +17,7 @@ content:
     weight: 0
     label: hidden
     settings:
-      set_marker: '1'
+      set_marker: true
       title: ''
       info_text:
         value: ''
@@ -295,8 +295,8 @@ content:
           google_maps_layer_transit:
             weight: 0
             enabled: false
-      use_overridden_map_settings: 0
-      common_map: '1'
+      use_overridden_map_settings: false
+      common_map: true
       data_provider_settings: {  }
     third_party_settings: {  }
     type: geolocation_map

--- a/config/uregni/config/core.entity_view_display.paragraph.map.embed.yml
+++ b/config/uregni/config/core.entity_view_display.paragraph.map.embed.yml
@@ -23,7 +23,7 @@ content:
     weight: 0
     label: hidden
     settings:
-      set_marker: '1'
+      set_marker: true
       title: ''
       info_text:
         value: ''
@@ -301,8 +301,8 @@ content:
           google_maps_layer_transit:
             weight: 0
             enabled: false
-      use_overridden_map_settings: 0
-      common_map: '1'
+      use_overridden_map_settings: false
+      common_map: true
       data_provider_settings: {  }
     third_party_settings: {  }
     type: geolocation_map

--- a/config/uregni/config/core.entity_view_display.paragraph.map.preview.yml
+++ b/config/uregni/config/core.entity_view_display.paragraph.map.preview.yml
@@ -23,7 +23,7 @@ content:
     weight: 0
     label: hidden
     settings:
-      set_marker: '1'
+      set_marker: true
       title: ''
       info_text:
         value: ''
@@ -84,8 +84,8 @@ content:
             settings:
               scroll_target_id: ''
             enabled: false
-      use_overridden_map_settings: 0
-      common_map: '1'
+      use_overridden_map_settings: false
+      common_map: true
       data_provider_settings: {  }
     third_party_settings: {  }
     type: geolocation_map

--- a/config/uregni/config/field.field.node.news.field_photo.yml
+++ b/config/uregni/config/field.field.node.news.field_photo.yml
@@ -1,40 +1,28 @@
-uuid: 4689713a-6c14-4322-9ef1-a3152178bb90
+uuid: 682e5e54-452c-483f-8564-47718f54a704
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_photo
+    - media.type.image
     - node.type.news
-  module:
-    - image
-_core:
-  default_config_hash: bnU62YoazPX0zS_vIf6WCR7dHdfdtrg_k9h-fEki5AY
 id: node.news.field_photo
 field_name: field_photo
 entity_type: node
 bundle: news
 label: Photo
-description: 'Please choose an image  to be displayed with this news item. '
+description: 'Please choose an image  to be displayed with this feature item. '
 required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: images/news
-  file_extensions: 'png gif jpg jpeg'
-  max_filesize: '5 MB'
-  max_resolution: ''
-  min_resolution: 600x400
-  alt_field: true
-  alt_field_required: false
-  title_field: false
-  title_field_required: false
-  default_image:
-    uuid: ''
-    alt: ''
-    title: ''
-    width: null
-    height: null
-  handler: 'default:file'
-  handler_settings: {  }
-field_type: image
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/uregni/config/field.field.node.page.field_page_top_image.yml
+++ b/config/uregni/config/field.field.node.page.field_page_top_image.yml
@@ -1,33 +1,28 @@
-uuid: 2f8092d9-4a2d-4fa6-8f17-51fb8ea19671
+uuid: 80160951-264b-42e9-8501-251095f10ebe
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_page_top_image
+    - media.type.image
     - node.type.page
-  module:
-    - image
 id: node.page.field_page_top_image
 field_name: field_page_top_image
 entity_type: node
 bundle: page
 label: 'Top image'
-description: ''
+description: 'Please choose an image  to be displayed with this page item. '
 required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: ''
-  file_extensions: 'png gif jpg jpeg'
-  max_filesize: ''
-  max_resolution: ''
-  min_resolution: 600x350
-  alt_field: false
-  title_field: false
-  default_image: 0
-  alt_field_required: true
-  title_field_required: false
-  handler: 'default:file'
-  handler_settings: {  }
-field_type: image
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/uregni/config/field.field.node.publication_page.field_publication_image.yml
+++ b/config/uregni/config/field.field.node.publication_page.field_publication_image.yml
@@ -1,38 +1,28 @@
-uuid: d73c4c46-3e4f-4083-93d7-be48c6e7bffc
+uuid: b14cd5b1-25e0-4d95-9e1f-b144c3a466a2
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_publication_image
+    - media.type.image
     - node.type.publication_page
-  module:
-    - image
 id: node.publication_page.field_publication_image
 field_name: field_publication_image
 entity_type: node
 bundle: publication_page
 label: Image
-description: 'Please choose an image to be displayed with the publication article.'
+description: 'Please choose an image  to be displayed with this publication article.'
 required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: ''
-  file_extensions: 'png gif jpg jpeg'
-  max_filesize: ''
-  max_resolution: ''
-  min_resolution: ''
-  alt_field: false
-  alt_field_required: true
-  title_field: false
-  title_field_required: false
-  default_image:
-    uuid: ''
-    alt: ''
-    title: ''
-    width: null
-    height: null
-  handler: 'default:file'
-  handler_settings: {  }
-field_type: image
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/uregni/config/field.field.node.staff_member.field_member_image.yml
+++ b/config/uregni/config/field.field.node.staff_member.field_member_image.yml
@@ -1,33 +1,28 @@
-uuid: bed8d836-a729-4f4b-a274-f2aa12ba5fc4
+uuid: f1a70f3a-5265-4413-be40-f2efe7ac6333
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_member_image
+    - media.type.image
     - node.type.staff_member
-  module:
-    - image
 id: node.staff_member.field_member_image
 field_name: field_member_image
 entity_type: node
 bundle: staff_member
 label: 'Member image'
-description: ''
+description: 'Please choose an image  to be displayed with this board member. '
 required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  alt_field: false
-  default_image: 0
-  file_directory: ''
-  file_extensions: 'png gif jpg jpeg'
-  max_filesize: ''
-  max_resolution: ''
-  min_resolution: 160x210
-  title_field: false
-  alt_field_required: true
-  title_field_required: false
-  handler: 'default:file'
-  handler_settings: {  }
-field_type: image
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/uregni/config/field.storage.node.field_member_image.yml
+++ b/config/uregni/config/field.storage.node.field_member_image.yml
@@ -1,23 +1,17 @@
-uuid: a0be48a0-15a3-4330-a907-9112b8f58b58
-langcode: und
+uuid: aadd76c5-6a88-4842-b0ee-16f0ceb62380
+langcode: en
 status: true
 dependencies:
   module:
-    - file
-    - image
+    - media
     - node
 id: node.field_member_image
 field_name: field_member_image
 entity_type: node
-type: image
+type: entity_reference
 settings:
-  default_image:
-    uuid: ''
-  uri_scheme: public
-  target_type: file
-  display_field: false
-  display_default: false
-module: image
+  target_type: media
+module: core
 locked: false
 cardinality: 1
 translatable: true

--- a/config/uregni/config/field.storage.node.field_page_top_image.yml
+++ b/config/uregni/config/field.storage.node.field_page_top_image.yml
@@ -1,23 +1,17 @@
-uuid: ec8ae60f-c915-4457-adea-ba41cb90c204
-langcode: und
+uuid: 245f4696-852a-44a0-84d8-e19052c0f34b
+langcode: en
 status: true
 dependencies:
   module:
-    - file
-    - image
+    - media
     - node
 id: node.field_page_top_image
 field_name: field_page_top_image
 entity_type: node
-type: image
+type: entity_reference
 settings:
-  default_image:
-    uuid: ''
-  uri_scheme: public
-  target_type: file
-  display_field: false
-  display_default: false
-module: image
+  target_type: media
+module: core
 locked: false
 cardinality: 1
 translatable: true

--- a/config/uregni/config/field.storage.node.field_photo.yml
+++ b/config/uregni/config/field.storage.node.field_photo.yml
@@ -1,25 +1,17 @@
-uuid: 4b1760d7-a218-4ef9-8780-1274c432e9b9
-langcode: und
+uuid: b7231278-a814-40f6-8824-1c5abcd4731f
+langcode: en
 status: true
 dependencies:
   module:
-    - file
-    - image
+    - media
     - node
-_core:
-  default_config_hash: 4onVLjhucxaFkwehtnrtPBYu5Qvm1diVRr_4XFmtD_M
 id: node.field_photo
 field_name: field_photo
 entity_type: node
-type: image
+type: entity_reference
 settings:
-  default_image:
-    uuid: ''
-  uri_scheme: public
-  target_type: file
-  display_field: false
-  display_default: false
-module: image
+  target_type: media
+module: core
 locked: false
 cardinality: 1
 translatable: true

--- a/config/uregni/config/field.storage.node.field_publication_image.yml
+++ b/config/uregni/config/field.storage.node.field_publication_image.yml
@@ -1,23 +1,17 @@
-uuid: b76f8830-ae86-4bb3-b1a4-d0179bfaa82d
-langcode: und
+uuid: df1a17ec-f9d5-4598-bd71-a6258823658d
+langcode: en
 status: true
 dependencies:
   module:
-    - file
-    - image
+    - media
     - node
 id: node.field_publication_image
 field_name: field_publication_image
 entity_type: node
-type: image
+type: entity_reference
 settings:
-  default_image:
-    uuid: ''
-  uri_scheme: public
-  target_type: file
-  display_field: false
-  display_default: false
-module: image
+  target_type: media
+module: core
 locked: false
 cardinality: 1
 translatable: true

--- a/config/uregni/config/views.view.publications_search.yml
+++ b/config/uregni/config/views.view.publications_search.yml
@@ -275,8 +275,8 @@ display:
         title: Publications
         description: ''
         expanded: false
-        parent: 'menu_link_content:f1f1af0b-e91f-4f43-8af2-185f4dd5a576'
-        weight: -45
+        parent: 'menu_link_content:2abe8855-e9be-4622-a328-6cba24c0fa19'
+        weight: 0
         context: '0'
         menu_name: main
     cache_metadata:

--- a/config/uregni/config/views.view.publications_search.yml
+++ b/config/uregni/config/views.view.publications_search.yml
@@ -275,8 +275,8 @@ display:
         title: Publications
         description: ''
         expanded: false
-        parent: 'menu_link_content:2abe8855-e9be-4622-a328-6cba24c0fa19'
-        weight: 0
+        parent: 'menu_link_content:f1f1af0b-e91f-4f43-8af2-185f4dd5a576'
+        weight: -45
         context: '0'
         menu_name: main
     cache_metadata:

--- a/web/sites/uregni/themes/uregni_theme/package.json
+++ b/web/sites/uregni/themes/uregni_theme/package.json
@@ -30,7 +30,7 @@
     "kss": "^3.0.1",
     "modernizr": "^3.11.2",
     "nicsdru_origins_theme": "^0.1.1",
-    "nicsdru_unity_theme": "^0.1.1",
+    "nicsdru_unity_theme": "^0.1.3",
     "nightwatch": "^1.3.5",
     "nightwatch-accessibility": "^1.8.0",
     "node-sass": "^4.14.1",


### PR DESCRIPTION
- Changing the image field to use an entity reference media field to match NIDirect.
- Updated displays to include new entity reference media fields.
- D8UN-98-responsive-images needs approval before image styles can be updated properly.
- Updated nicsdru_unity_theme package.
- Added in lingering config files, seem to just be updates to structure i.e. 1 - true, 0 - false.