### PR TITLE
Removing board member content type from using sidebar menu

### DIFF
--- a/config/uregni/config/block.block.sidemenu.yml
+++ b/config/uregni/config/block.block.sidemenu.yml
@@ -28,7 +28,6 @@ visibility:
     id: node_type
     bundles:
       page: page
-      staff_member: staff_member
       vacancy: vacancy
     negate: false
     context_mapping:


### PR DESCRIPTION
Having the sidebar menu enabled for Board member is adding a blank block and affecting the styling. removing the content type from config fixes this.