### PR TITLE
D8UN-200

### DIFF
--- a/config/uregni/config/core.extension.yml
+++ b/config/uregni/config/core.extension.yml
@@ -99,6 +99,7 @@ module:
   unity_search_pages: 0
   uregni_breadcrumbs: 0
   user: 0
+  views_custom_cache_tag: 0
   webform: 0
   webform_access: 0
   webform_node: 0

--- a/config/uregni/config/core.extension.yml
+++ b/config/uregni/config/core.extension.yml
@@ -44,6 +44,7 @@ module:
   geolocation_google_maps: 0
   geolocation_google_static_maps: 0
   geolocation_search_api: 0
+  handy_cache_tags: 0
   help: 0
   history: 0
   image: 0

--- a/config/uregni/config/views.view.board_member.yml
+++ b/config/uregni/config/views.view.board_member.yml
@@ -30,7 +30,7 @@ display:
       cache:
         type: custom_tag
         options:
-          custom_tag: 'node:type:{{ raw_arguments.type }}'
+          custom_tag: 'handy_cache_tags:node:staff_member'
       query:
         type: views_query
         options:

--- a/config/uregni/config/views.view.board_member.yml
+++ b/config/uregni/config/views.view.board_member.yml
@@ -8,6 +8,7 @@ dependencies:
   module:
     - node
     - user
+    - views_custom_cache_tag
 id: board_member
 label: 'Board members'
 module: views
@@ -27,8 +28,9 @@ display:
         options:
           perm: 'access content'
       cache:
-        type: tag
-        options: {  }
+        type: custom_tag
+        options:
+          custom_tag: 'node:type:{{ raw_arguments.type }}'
       query:
         type: views_query
         options:

--- a/config/uregni/config/views.view.latest_news.yml
+++ b/config/uregni/config/views.view.latest_news.yml
@@ -9,6 +9,7 @@ dependencies:
     - datetime
     - node
     - user
+    - views_custom_cache_tag
 id: latest_news
 label: 'Latest news'
 module: views
@@ -28,12 +29,9 @@ display:
         options:
           perm: 'access content'
       cache:
-        type: time
+        type: custom_tag
         options:
-          results_lifespan: 1800
-          results_lifespan_custom: 0
-          output_lifespan: 1800
-          output_lifespan_custom: 0
+          custom_tag: 'node:type:{{ raw_arguments.type }}'
       query:
         type: views_query
         options:

--- a/config/uregni/config/views.view.latest_news.yml
+++ b/config/uregni/config/views.view.latest_news.yml
@@ -31,7 +31,7 @@ display:
       cache:
         type: custom_tag
         options:
-          custom_tag: 'node:type:{{ raw_arguments.type }}'
+          custom_tag: 'handy_cache_tags:node:news'
       query:
         type: views_query
         options:

--- a/config/uregni/config/views.view.search.yml
+++ b/config/uregni/config/views.view.search.yml
@@ -616,6 +616,7 @@ display:
         filter_groups: false
         fields: false
         pager: false
+        cache: false
       filter_groups:
         operator: AND
         groups:
@@ -696,6 +697,9 @@ display:
         options:
           items_per_page: 5
           offset: 0
+      cache:
+        type: none
+        options: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/uregni/config/views.view.vacancies.yml
+++ b/config/uregni/config/views.view.vacancies.yml
@@ -10,6 +10,7 @@ dependencies:
     - datetime
     - node
     - user
+    - views_custom_cache_tag
 id: vacancies
 label: Vacancies
 module: views
@@ -29,8 +30,9 @@ display:
         options:
           perm: 'access content'
       cache:
-        type: tag
-        options: {  }
+        type: custom_tag
+        options:
+          custom_tag: 'handy_cache_tags:node:vacancy'
       query:
         type: views_query
         options:


### PR DESCRIPTION
This PR is the result of checking the usage of cache tags across the Uregni site.

The following changes have been made:
- Installed handy_cache_tags and views_custom_cache_tag contrib modules to allow more fine grained control over cache tags
- Removed 'node_list' cache tag from 'Board Member' view
- Removed 'node_list' cache tag from 'Vacancies' view
- Removed 'node_list' cache tag from 'Latest News' view (on homepage)
- Removed 'search_api.index.default_content' cache tag from the embedded site search form