### PR TITLE
D8UN-196

### DIFF
--- a/config/uregni/config/views.view.workflow_moderation.yml
+++ b/config/uregni/config/views.view.workflow_moderation.yml
@@ -8,7 +8,9 @@ dependencies:
     - user.role.author_user
     - user.role.editor_user
     - user.role.supervisor_user
+    - workflows.workflow.nics_editorial_workflow
   module:
+    - content_moderation
     - datetime
     - node
     - user
@@ -1647,6 +1649,55 @@ display:
           empty_zero: false
           hide_alter_empty: false
           plugin_id: custom
+        nothing_2:
+          id: nothing_2
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Set moderation state'
+          exclude: false
+          alter:
+            alter_text: true
+            text: "{% if moderation_state_1 == \"Needs Review\" %}\r\n  <div><a href='/origins_workflow/change_state/{{ nid }}/draft?destination=/admin/content/all-drafts'>Change to Draft</a></div>\r\n  <div><a href='/origins_workflow/change_state/{{ nid }}/published?destination=/admin/content/all-drafts'>Change to Published</a></div>\r\n{% else %}\r\n  <div><a href='/origins_workflow/change_state/{{ nid }}/needs_review?destination=/admin/content/all-drafts'>Change to Needs Review</a></div>\r\n{% endif %}\r\n"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+          plugin_id: custom
         title:
           id: title
           table: node_field_data
@@ -2602,6 +2653,55 @@ display:
           element_label_type: ''
           element_label_class: ''
           element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+          plugin_id: custom
+        nothing_2:
+          id: nothing_2
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Set moderation state'
+          exclude: false
+          alter:
+            alter_text: true
+            text: "{% if moderation_state_1 == \"Needs Review\" %}\r\n  <div><a href='/origins_workflow/change_state/{{ nid }}/draft?destination=/admin/content/drafts'>Change to Draft</a></div>\r\n  <div><a href='/origins_workflow/change_state/{{ nid }}/published?destination=/admin/content/drafts'>Change to Published</a></div>\r\n{% else %}\r\n  <div><a href='/origins_workflow/change_state/{{ nid }}/needs_review?destination=/admin/content/drafts'>Change to Needs Review</a></div>\r\n{% endif %}\r\n"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true


### PR DESCRIPTION
Finer grained permission checks on drafts views
- User must have 'quick publish' permission to publish from 'drafts' or 'all drafts' view
- If user does not have 'quick publish' permission but does have 'publish' then they can publish 'needs review' content but not 'draft' content

Relates to https://github.com/dof-dss/nicsdru_origins_modules/pull/108