### PR TITLE
D8 un 250

### DIFF
--- a/config/uregni/config/core.entity_view_display.node.vacancy.default.yml
+++ b/config/uregni/config/core.entity_view_display.node.vacancy.default.yml
@@ -56,7 +56,7 @@ content:
     weight: 4
     label: above
     settings:
-      view_mode: default
+      view_mode: embed
       link: false
     third_party_settings: {  }
     region: content

--- a/web/sites/uregni/modules/custom/uregni_migrations/config/install/migrate_plus.migration.upgrade_d7_file_document.yml
+++ b/web/sites/uregni/modules/custom/uregni_migrations/config/install/migrate_plus.migration.upgrade_d7_file_document.yml
@@ -22,7 +22,7 @@ process:
     plugin: default_value
     source: language
     default_value: "und"
-  name: filename
+  name: field_file_title
   uid:
     -
       plugin: skip_on_empty

--- a/web/sites/uregni/themes/uregni_theme/templates/field/field--node--field-vacancy-attachments.html.twig
+++ b/web/sites/uregni/themes/uregni_theme/templates/field/field--node--field-vacancy-attachments.html.twig
@@ -58,7 +58,7 @@
   <div{{ attributes }}>
     <h2{{ title_attributes.addClass(title_classes) }}>{{ label }}</h2>
     {% if multiple %}
-      <ul>
+      <ul class="list--no-bullet">
     {% endif %}
     {% for item in items %}
       <li{{ item.attributes }}>{{ item.content }}</li>


### PR DESCRIPTION
Changes to make sure that media document titles are migrated across from D7 rather than just using the filename.
- Change migration to use title field
- Change vacancy attachment display to 'embed'
- Change to Uregni theme to add class to unordered list to pick up styling for vacancy attachments