### PR TITLE
D8 un 248

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,6 +286,35 @@ jobs:
               echo "No active environment for $EDGE_BUILD_BRANCH found, attempt to activate one."
               /home/circleci/.platformsh/bin/platform environment:activate -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH -y
             fi
+  # Nightly edge build deployment
+  unity_edge_build_deploy:
+    docker:
+      - image: circleci/php:7.3.14-apache-browsers
+    steps:
+      - attach_workspace:
+          at: ./
+      - install_php_os_extensions
+      - run:
+          name: Add extra OS and PHP extensions/config
+          command: |
+            sudo docker-php-ext-install pcntl posix
+      - run:
+          name: Keyscan Platform.sh region hostnames + GitHub for password-less access
+          command: |
+            mkdir -p ~/.ssh
+            ssh-keyscan -H ssh.$PLATFORM_REGION >> ~/.ssh/known_hosts
+            ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+      - run:
+          name: Install the Platform.sh CLI tool
+          command: |
+            curl -sS https://platform.sh/cli/installer | php
+      - run:
+          name: Activate the environment if not found.
+          command: |
+            if ! /home/circleci/.platformsh/bin/platform environment:list -p $PLATFORM_PROJECT_ID -I --no-header --pipe | grep -q $EDGE_BUILD_BRANCH; then
+              echo "No active environment for $EDGE_BUILD_BRANCH found, attempt to activate one."
+              /home/circleci/.platformsh/bin/platform environment:activate -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH -y
+            fi
 
 workflows:
   version: 2
@@ -330,6 +359,13 @@ workflows:
     jobs:
       - build
       - unity_edge_build:
+          requires:
+            - build
+
+  nightly-edge-build-deploy:
+    jobs:
+      - build
+      - unity_edge_build_deploy:
           requires:
             - build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,7 +309,7 @@ jobs:
           command: |
             curl -sS https://platform.sh/cli/installer | php
       - run:
-          name: Activate the environment if not found.
+          name: Deploy or re-deploy the edge environment.
           command: |
             if /home/circleci/.platformsh/bin/platform environment:list -p $PLATFORM_PROJECT_ID -I --no-header --pipe | grep -q $EDGE_BUILD_BRANCH; then
               echo "Re-deploying $EDGE_BUILD_BRANCH"
@@ -365,7 +365,16 @@ workflows:
           requires:
             - build
 
+  # A nightly deploy or re-deploy of the edge site after the git branch has been created in nightly-edge-build.
   nightly-edge-build-deploy:
+    triggers:
+      - schedule:
+          # At 01:00 Monday to Friday
+          cron: "0 1 * * 1-5"
+          filters:
+            branches:
+              only:
+                - development
     jobs:
       - build
       - unity_edge_build_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,7 +311,10 @@ jobs:
       - run:
           name: Activate the environment if not found.
           command: |
-            if ! /home/circleci/.platformsh/bin/platform environment:list -p $PLATFORM_PROJECT_ID -I --no-header --pipe | grep -q $EDGE_BUILD_BRANCH; then
+            if /home/circleci/.platformsh/bin/platform environment:list -p $PLATFORM_PROJECT_ID -I --no-header --pipe | grep -q $EDGE_BUILD_BRANCH; then
+              echo "Re-deploying $EDGE_BUILD_BRANCH"
+              /home/circleci/.platformsh/bin/platform environment:redeploy -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH -y
+            else
               echo "No active environment for $EDGE_BUILD_BRANCH found, attempt to activate one."
               /home/circleci/.platformsh/bin/platform environment:activate -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH -y
             fi


### PR DESCRIPTION
Add an extra 'nightly edge build deploy' job that comes along after the edge git branch has been updated and re-deploys the edge site (so that the database gets pulled down from master).