### PR TITLE
reduce number of sites deployed

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -75,7 +75,7 @@ hooks:
     set -e
 
     # For each multi site - rebuild caches, run db-updates and import config.
-    for site in uregni odscni hatecrimereviewni fiscalcommissionni nifiscalcouncil attorneygeneralni employmenttribunalsni liofa fictcommission
+    for site in uregni odscni fiscalcommissionni
     do
       echo "****** $site deployment ******"
       cd /app/web/sites/$site


### PR DESCRIPTION
To speed up deployments, we should only run these commands for sites that are live or are currently being worked on.