### PR TITLE
Attaching custom styles to the media library view

### DIFF
--- a/config/odscni/config/core.entity_view_display.media.image.media_library.yml
+++ b/config/odscni/config/core.entity_view_display.media.image.media_library.yml
@@ -22,19 +22,19 @@ targetEntityType: media
 bundle: image
 mode: media_library
 content:
-  field_media_image:
+  thumbnail:
+    type: image
+    weight: 0
+    region: content
     label: hidden
     settings:
       image_style: medium
       image_link: ''
     third_party_settings: {  }
-    type: image
-    weight: 1
-    region: content
 hidden:
   created: true
   field_caption: true
+  field_media_image: true
   langcode: true
   name: true
-  thumbnail: true
   uid: true

--- a/web/modules/custom/unity_common/unity_common.module
+++ b/web/modules/custom/unity_common/unity_common.module
@@ -6,11 +6,9 @@
  */
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Link;
-use Drupal\file\Entity\File;
 use Drupal\file\FileInterface;
 use Drupal\media\MediaInterface;
-use Drupal\views\Render\ViewsRenderPipelineMarkup;
+use Drupal\views\ViewExecutable;
 
 /**
  * Implements hook_preprocess_page().
@@ -51,6 +49,16 @@ function unity_common_form_alter(&$form, FormStateInterface $form_state, $form_i
       $form_state,
       ['honeypot', 'time_restriction']
     );
+  }
+}
+
+/**
+ * Implements hook_views_pre_render().
+ */
+function unity_common_views_pre_render(ViewExecutable $view) {
+  // Attach origins media library styles to media library views.
+  if ($view->id() === 'media_library') {
+    $view->element['#attached']['library'][] = 'nicsdru_unity_theme/media_library_styles';
   }
 }
 


### PR DESCRIPTION
Origins media module attaches a custom library to the media view from nicsdru_origins_theme. We don't have direct access to that in unity so I have replicated the code from origins_media and attached a custom library from nicsdru_unity_theme.