### PR TITLE
D8UN-594

### DIFF
--- a/web/sites/uregni/themes/uregni_theme/uregni_theme.theme
+++ b/web/sites/uregni/themes/uregni_theme/uregni_theme.theme
@@ -207,7 +207,7 @@ function uregni_theme_preprocess_field(&$variables) {
         $body_text = &$variables['items'][0]['content']['#text'];
         // Set a regex pattern to look for body links. We don't want to target body links nested in text.
         // A pattern we want to match is:
-        // <a href="/files/uregni/media-files/24%20May%20board%20minutes%20%28signed%29.pdf"></a>
+        // <a href="/files/uregni/media-files/24%20May%20board%20minutes%20%28signed%29.pdf"></a>.
         $embed_regex = '/<a[\w\s\.]*href="(\/files\/.*?.([a-z]*))"\>(((?!\<\/a\>).)*)\<\/a\>/';
         $matches = [];
         // Search the body text for the regex pattern and split the result in matches to be used.

--- a/web/sites/uregni/themes/uregni_theme/uregni_theme.theme
+++ b/web/sites/uregni/themes/uregni_theme/uregni_theme.theme
@@ -207,7 +207,7 @@ function uregni_theme_preprocess_field(&$variables) {
         $body_text = &$variables['items'][0]['content']['#text'];
         // Set a regex pattern to look for body links. We don't want to target body links nested in text.
         // A pattern we want to match is:
-        // <div><a href="https://www.uregni.gov.uk/sites/uregni/files/media-files/2019-11-22%20Switchgear%20TNPP%20-%20Final%20Decision.pdf"></a>
+        // <a href="/files/uregni/media-files/24%20May%20board%20minutes%20%28signed%29.pdf"></a>
         $embed_regex = '/<a[\w\s\.]*href="(\/files\/.*?.([a-z]*))"\>(((?!\<\/a\>).)*)\<\/a\>/';
         $matches = [];
         // Search the body text for the regex pattern and split the result in matches to be used.

--- a/web/sites/uregni/themes/uregni_theme/uregni_theme.theme
+++ b/web/sites/uregni/themes/uregni_theme/uregni_theme.theme
@@ -208,7 +208,7 @@ function uregni_theme_preprocess_field(&$variables) {
         // Set a regex pattern to look for body links. We don't want to target body links nested in text.
         // A pattern we want to match is:
         // <div><a href="https://www.uregni.gov.uk/sites/uregni/files/media-files/2019-11-22%20Switchgear%20TNPP%20-%20Final%20Decision.pdf"></a>
-        $embed_regex = '/<[a-z]{1,3}><a[\w\s\.]*href="([^"]*?.([a-z]*))"\>(((?!\<\/a\>).)*)\<\/a\>/';
+        $embed_regex = '/<a[\w\s\.]*href="(\/files\/.*?.([a-z]*))"\>(((?!\<\/a\>).)*)\<\/a\>/';
         $matches = [];
         // Search the body text for the regex pattern and split the result in matches to be used.
         preg_match_all($embed_regex, $body_text, $matches, PREG_SET_ORDER);


### PR DESCRIPTION
Fixing regex so it on matches /files/ path. The previous regex was also matching /node/ paths and adding an empty file icon beside it.
It was also stripping out the li tag from the HTML so as we are now being more specific in our regex we don't need the opening <[a-z]{1,3}>