### PR TITLE
turn off unit tests for Unity as there aren't any

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,9 +494,9 @@ workflows:
       - deprecated_code:
           requires:
             - build
-      - unit_kernel_tests:
-          requires:
-            - build
+#      - unit_kernel_tests:
+#          requires:
+#            - build
       - deploy_solr_rebuild:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,7 +494,7 @@ workflows:
       - deprecated_code:
           requires:
             - build
-#  Comment out the tests until tehre are some to run !
+#  Comment out the tests until there are some to run !
 #      - unit_kernel_tests:
 #          requires:
 #            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,6 +494,7 @@ workflows:
       - deprecated_code:
           requires:
             - build
+#  Comment out the tests until tehre are some to run !
 #      - unit_kernel_tests:
 #          requires:
 #            - build


### PR DESCRIPTION
At the moment, running these tests just adds 6 minutes to every build, we can reinstate this step if we do start to write tests