### PR TITLE
Remove prestissimo; redundant with composer 2

### DIFF
--- a/.lando/scripts/appserver_build.sh
+++ b/.lando/scripts/appserver_build.sh
@@ -10,9 +10,6 @@ DRUPAL_CUSTOM_CODE=$DRUPAL_ROOT/modules/custom
 # of supporting software or config files.
 NODE_YARN_INSTALLED=/etc/NODE_YARN_INSTALLED
 
-# Add hirak/prestissimo to speed up composer downloads.
-composer global require hirak/prestissimo --no-interaction
-
 # Create export directories for config and data.
 if [ ! -d "/app/.lando/exports" ]; then
   echo "Creating export directories"


### PR DESCRIPTION
Causes confusion and possibly provisioning headaches based on experiences by myself and @ooneill547 this week. Prestissimo is no longer needed as composer 2 supports concurrent downloads whereas composer 1 did not.