### PR TITLE
Substituting single quote for double quotes around drush command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,9 +244,9 @@ jobs:
                     "curl http://${site}_solr.internal:8080/solr/${site}_index/update --data '<delete><query>*:*</query></delete>' -H 'Content-type:text/xml; charset=utf-8' \
                       && curl http://${site}_solr.internal:8080/solr/${site}_index/update --data '<commit/>' -H 'Content-type:text/xml; charset=utf-8'"
                   echo "***** Rebuild the Solr index for - ${site} *****"
-                  platform drush 'sapi-c -l ${site}' -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH
-                  platform drush 'sapi-r -l ${site}' -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH
-                  platform drush 'sapi-i -l ${site}' -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH
+                  platform drush "sapi-c -l ${site}" -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH
+                  platform drush "sapi-r -l ${site}" -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH
+                  platform drush "sapi-i -l ${site}" -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH
                 fi
               fi
             done


### PR DESCRIPTION
Turns out you get an odd bootstrap error without this.