### PR TITLE
Config ignore settings for social media links

### DIFF
--- a/config/independentreviewofeducation/config/config_ignore.settings.yml
+++ b/config/independentreviewofeducation/config/config_ignore.settings.yml
@@ -1,3 +1,8 @@
-ignored_config_entities: {  }
+ignored_config_entities:
+  - 'independentreviewofeducation_theme.settings:twitter_profile_url'
+  - 'independentreviewofeducation_theme.settings:facebook_profile_url'
+  - 'independentreviewofeducation_theme.settings:linkedin_profile_url'
+  - 'independentreviewofeducation_theme.settings:pinterest_profile_url'
+  - 'independentreviewofeducation_theme.settings:youtube_profile_url'
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk


### PR DESCRIPTION
We don't want the social media config to be overwritten on a deployment so adding the settings in to be ignored.