### PR TITLE
Fix edge build on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
     <<: *docker_image
     steps:
       - checkout_code
+      - composer_tasks
       - persist_to_workspace:
           root: ./
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,13 @@
 version: 2.1
 
+# Default docker image. (excludes functional_tests)
+default_docker_image: &docker_image
+  docker:
+    - image: thecodingmachine/php:8.0-v4-apache-node12
+      environment:
+        PHP_EXTENSION_GD: 1
+        PHP_INI_MEMORY_LIMIT: 1g
+
 # Re-usable commands.
 commands:
   checkout_code:
@@ -53,18 +61,6 @@ commands:
       - run:
           name: Add platform cli tool to $PATH
           command: echo 'export PATH="$HOME/"'.platformsh/bin':"$PATH"' >> $BASH_ENV
-
-  install_php_os_extensions:
-    description: "Install a standard group of extensions and packages"
-    steps:
-      - run:
-          name: Add OS and PHP extensions
-          command: |
-            sudo cp /home/circleci/project/.circleci/docker-php-circleci.ini /usr/local/etc/php/conf.d/
-            wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-            sudo apt-get update --allow-releaseinfo-change
-            sudo apt-get install -y libpng-dev
-            sudo docker-php-ext-install gd pcntl posix
   hosts_keyscan:
     description: "Adds github.com to known hosts in container; for working locally."
     steps:
@@ -77,27 +73,21 @@ commands:
 jobs:
   # Tests the integrity of the build, stores the results in a workspace for re-use in later jobs.
   build:
-    docker:
-      - image: circleci/php:8.0-apache-browsers
+    <<: *docker_image
     steps:
       - checkout_code
-      - install_php_os_extensions
-      - composer_tasks
       - persist_to_workspace:
           root: ./
           paths:
             - ./
-
   # Test for coding standards - will inherit the workspace/filesystem changes from build step, above.
   coding_standards:
-    docker:
-      - image: circleci/php:8.0-apache-browsers
+    <<: *docker_image
     environment:
-      PROJECT_ROOT: "/home/circleci/project"
+      PROJECT_ROOT: "/home/docker/project"
     steps:
       - attach_workspace:
           at: ./
-      - run: sudo cp /home/circleci/project/.circleci/docker-php-circleci.ini /usr/local/etc/php/conf.d/
       - run:
           name: PHPCS analysis
           command: |
@@ -111,26 +101,23 @@ jobs:
 
   # Test for deprecated code - will inherit the workspace/filesystem changes from build step, above.
   deprecated_code:
-    docker:
-      - image: circleci/php:8.0-apache-browsers
+    <<: *docker_image
     environment:
-      PROJECT_ROOT: "/home/circleci/project"
+      PROJECT_ROOT: "/home/docker/project"
     steps:
       - attach_workspace:
           at: ./
-      - run: sudo cp /home/circleci/project/.circleci/docker-php-circleci.ini /usr/local/etc/php/conf.d/
       - run:
           name: Deprecated code check
           command: |
-            cd /home/circleci/project
+            cd $PROJECT_ROOT
             CHECK_DIRS="${PROJECT_ROOT}/web/modules/custom"
             CHECK_DIRS="$CHECK_DIRS ${PROJECT_ROOT}/web/modules/origins"
             vendor/bin/drupal-check $CHECK_DIRS
 
   # Nightly edge build
   edge_build:
-    docker:
-      - image: circleci/php:8.0-apache-browsers
+    <<: *docker_image
     environment:
       # git variables to avoid empty committer identity errors
       EMAIL: "circleci@localhost"
@@ -141,7 +128,6 @@ jobs:
     steps:
       - hosts_keyscan
       - checkout_code
-      - install_php_os_extensions
       - install_psh_cli
       - run:
           name: Switch to edge branch
@@ -191,12 +177,10 @@ jobs:
 
   # Separate task to allow us to sync data on PSH environments, without pauses in other jobs.
   sync_data:
-    docker:
-      - image: circleci/php:8.0-apache-browsers
+    <<: *docker_image
     steps:
       - hosts_keyscan
       - checkout_code
-      - install_php_os_extensions
       - install_psh_cli
       - run:
           name: Trigger a data sync from master environment to nightly edge build.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,12 @@ version: 2.1
 # Default docker image. (excludes functional_tests)
 default_docker_image: &docker_image
   docker:
-    - image: thecodingmachine/php:8.0-v4-apache-node12
+    - image: thecodingmachine/php:8.0-v4-apache-node14
       environment:
         PHP_EXTENSION_GD: 1
         PHP_INI_MEMORY_LIMIT: 1g
+        PLATFORM_REGION: "uk-1.platform.sh"
+        PROJECT_ROOT: "/home/docker/project"
 
 # Re-usable commands.
 commands:
@@ -51,7 +53,9 @@ commands:
       - run:
           name: Switch dof-dss packages to HEAD on develelopment branch
           command: |
-            composer require dof-dss/nicsdru_unity_theme:dev-development dof-dss/nicsdru_origins_modules:dev-development dof-dss/nicsdru_unity_modules:dev-development
+            composer require dof-dss/nicsdru_unity_theme:dev-development \
+            dof-dss/nicsdru_origins_modules:dev-development \
+            dof-dss/nicsdru_unity_modules:dev-development
   install_psh_cli:
     description: "Install the Platform.sh CLI tool"
     steps:
@@ -84,8 +88,6 @@ jobs:
   # Test for coding standards - will inherit the workspace/filesystem changes from build step, above.
   coding_standards:
     <<: *docker_image
-    environment:
-      PROJECT_ROOT: "/home/docker/project"
     steps:
       - attach_workspace:
           at: ./
@@ -103,8 +105,6 @@ jobs:
   # Test for deprecated code - will inherit the workspace/filesystem changes from build step, above.
   deprecated_code:
     <<: *docker_image
-    environment:
-      PROJECT_ROOT: "/home/docker/project"
     steps:
       - attach_workspace:
           at: ./
@@ -125,7 +125,6 @@ jobs:
       GIT_COMMITTER_NAME: "Circle CI"
       GIT_AUTHOR_NAME: "Circle CI"
       EDGE_BUILD_BRANCH: "D8UN-edge"
-      PLATFORM_REGION: "uk-1.platform.sh"
     steps:
       - hosts_keyscan
       - checkout_code
@@ -144,22 +143,16 @@ jobs:
           command: |
             # Need to re-build site theme with any Unity changes.
             # Download and configure node and npm.
-            sudo apt install libjpeg-dev automake python
-            git clone git@github.com:nvm-sh/nvm.git
-            cd nvm
-            chmod +x install.sh
-            ./install.sh
+            sudo apt update
+            sudo apt install build-essential libjpeg-dev automake python3 -y
       - run:
           name: Rebuild site themes
           command: |
-            export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
-            nvm install v15.14.0
             for site in `ls -l ~/project/web/sites | grep ^d | awk '{print $9}'`
             do
-              if [[ -d ~/project/web/sites/${site}/themes/${site}_theme ]]; then
+              if [[ -d $PROJECT_ROOT/web/sites/${site}/themes/${site}_theme ]]; then
                 echo "*** Building theme for ${site} ***"
-                cd ~/project/web/sites/${site}/themes/${site}_theme
+                cd $PROJECT_ROOT/web/sites/${site}/themes/${site}_theme
                 sed -i -e "s/\"nicsdru_unity_theme.*/\"nicsdru_unity_theme\": \"github:dof-dss\/nicsdru_unity_theme#development\",/" package.json
                 npm install
                 npm rebuild node-sass
@@ -168,7 +161,7 @@ jobs:
                 git add *.css
                 git commit -m "Theme rebuild"
               else
-                echo "No theme folder detected under ~/project/web/sites/${site}/themes/${site}_theme, skipping."
+                echo "No theme folder detected under ${PROJECT_ROOT}/web/sites/${site}/themes/${site}_theme, skipping."
               fi
             done
 


### PR DESCRIPTION
- Removes custom nodejs install with nvm as node 14 already bundled in the docker image.
- Shunt some common env vars into the docker yml fragment, for brevity.