### PR TITLE
Reinstate past convenience image with custom theme compilation steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,18 @@ default_docker_image: &docker_image
         PLATFORM_REGION: "uk-1.platform.sh"
         PROJECT_ROOT: "/home/docker/project"
 
+custom_npm_docker_image: &custom_npm_docker_image
+  docker:
+    - image: circleci/php:8.0-apache-browsers
+      environment:
+        PLATFORM_REGION: "uk-1.platform.sh"
+        PROJECT_ROOT: "/home/circleci/project"
+        # git variables to avoid empty committer identity errors
+        EMAIL: "circleci@localhost"
+        GIT_COMMITTER_NAME: "Circle CI"
+        GIT_AUTHOR_NAME: "Circle CI"
+        EDGE_BUILD_BRANCH: "D8UN-edge"
+
 # Re-usable commands.
 commands:
   checkout_code:
@@ -118,16 +130,18 @@ jobs:
 
   # Nightly edge build
   edge_build:
-    <<: *docker_image
-    environment:
-      # git variables to avoid empty committer identity errors
-      EMAIL: "circleci@localhost"
-      GIT_COMMITTER_NAME: "Circle CI"
-      GIT_AUTHOR_NAME: "Circle CI"
-      EDGE_BUILD_BRANCH: "D8UN-edge"
+    <<: *custom_npm_docker_image
     steps:
       - hosts_keyscan
       - checkout_code
+      - run:
+          name: Add OS and PHP extensions
+          command: |
+            sudo cp /home/circleci/project/.circleci/docker-php-circleci.ini /usr/local/etc/php/conf.d/
+            wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+            sudo apt-get update --allow-releaseinfo-change
+            sudo apt-get install -y libpng-dev
+            sudo docker-php-ext-install gd pcntl posix
       - install_psh_cli
       - run:
           name: Switch to edge branch
@@ -143,11 +157,17 @@ jobs:
           command: |
             # Need to re-build site theme with any Unity changes.
             # Download and configure node and npm.
-            sudo apt update
-            sudo apt install build-essential libjpeg-dev automake python3 -y
+            sudo apt install automake python libjpeg-dev -y
+            git clone https://github.com/nvm-sh/nvm.git
+            cd nvm
+            chmod +x install.sh
+            ./install.sh
       - run:
           name: Rebuild site themes
           command: |
+            export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
+            nvm install v15.14.0
             for site in `ls -l ~/project/web/sites | grep ^d | awk '{print $9}'`
             do
               if [[ -d $PROJECT_ROOT/web/sites/${site}/themes/${site}_theme ]]; then


### PR DESCRIPTION
Some minor shuffling of YAML blocks, but pretty much reinstate last convenience image for this job as the new images have some internal differences that mean npm doesn't have every system package or tool available to it to successfully compile the SASS code.

Future work aims to standardise on, I believe, node 16 which means we can review this job again at a point where it either develops problems or we can take an easier upgrade route.