### PR TITLE
Updating honeypot module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,7 @@
         "drupal/google_analytics": "^3.1",
         "drupal/google_tag": "^1.5",
         "drupal/handy_cache_tags": "^1.0",
-        "drupal/honeypot": "^2.0",
+        "drupal/honeypot": "^2.1",
         "drupal/http_cache_control": "^2.0",
         "drupal/inline_entity_form": "^1.0@RC",
         "drupal/layout_builder_restrictions": "^2.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e5288ffb92b90d7ba0c0bbcb77786df",
+    "content-hash": "b0dfa70916190ba56d6350e061ff408b",
     "packages": [
         {
             "name": "alchemy/zippy",


### PR DESCRIPTION
As per @johangant comment "Noted from discussion with @soda736 today that this PR might now be superseded by upstream changes. Providing honeypot's at least version 2.1 this PR can be closed 👍" on PR https://github.com/dof-dss/nicsdru_unity/pull/1450
Updating honeypot so his PR can be closed.