### PR TITLE
Adjust rebuild theme script to take two optional params for sites dir and names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
             nvm install v14.21.3
             cd $PROJECT_ROOT
-            ./build-themes.sh $PROJECT_ROOT/project/sites
+            ./build-themes.sh --sites-dir $PROJECT_ROOT/project/sites
 
             # Push to fixed, non-integrating build branch. GitHub webhook integration will propagate this
             # to platform.sh for later steps to use.

--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -168,7 +168,7 @@ tooling:
       > Rebuild all site themes\n
       lando rebuild-unity-site-themes\n
       > Rebuild single site theme\n
-      lando rebuild-unity-site-themes octf\n
+      lando rebuild-unity-site-themes --site-names octf\n
       > Rebuild site themes specified - comma separated\n
-      lando rebuild-unity-site-themes octf,pbni"
+      lando rebuild-unity-site-themes --site-names octf,pbni"
     cmd: "/app/build-themes.sh"

--- a/build-themes.sh
+++ b/build-themes.sh
@@ -2,17 +2,37 @@
 
 echo "Starting unity theme update"
 
-# Define the path to the 'sites' directory
+# Defaults
 sites_dir="/app/project/sites"
+site_names=()
 
-if [ "$#" -gt 0 ]; then
-    # If site names are provided, process them
-    IFS=',' read -r -a site_names <<< "$1"
-else
-    # If no site names are provided, get all site names
+# Parse named parameters
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        --sites-dir)
+            sites_dir="$2"
+            shift
+            shift
+            ;;
+        --site-names)
+            IFS=',' read -r -a site_names <<< "$2"
+            shift
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# If no site names provided, process all sites
+if [ ${#site_names[@]} -eq 0 ]; then
     site_names=($(ls -1 "$sites_dir"))
 fi
 
+# Process each site
 for site_name in "${site_names[@]}"; do
     # Trim leading and trailing whitespace from site name
     site_name=$(echo "$site_name" | xargs)


### PR DESCRIPTION
Usage examples:

- `./build-themes.sh` build all site themes with default sites dir of /app/project/sites
- `./build-themes.sh --sites-dir $PROJECT_ROOT/project/sites --site-names uregni,octf` build two sites with overridden sites-dir variable

By varying the parameters you can build some/all themes on Lando or in Circle CI containers which have a different internal site path
