### PR TITLE
Install legacy npm version using newer installer script

### DIFF
--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -17,10 +17,16 @@ services:
     scanner: false
     overrides:
       environment:
+        # Set node compilation flag to allow arm64 and x86 chipset compilation.
         CPPFLAGS: "-DPNG_ARM_NEON_OPT=0"
+        # node version set here will be used by the nvm installer script.
+        NODE_VERSION: 14.21.3
     xdebug: debug
     build_as_root:
       - /app/.lando/scripts/appserver_build.sh
+    run:
+      - touch ~/.bashrc
+      - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
   database:
     build_as_root:
       - "sh /app/.lando/scripts/create_databases.sh"

--- a/.lando/scripts/appserver_build.sh
+++ b/.lando/scripts/appserver_build.sh
@@ -4,10 +4,6 @@
 DRUPAL_ROOT=/app/web
 DRUPAL_CUSTOM_CODE=$DRUPAL_ROOT/modules/custom
 
-# Semaphore files to control whether we need to trigger an install
-# of supporting software or config files.
-NODE_YARN_INSTALLED=/etc/NODE_YARN_INSTALLED
-
 # Set Simple test variables and put PHPUnit config in place.
 if [ ! -f "${DRUPAL_ROOT}/core/phpunit.xml" ]; then
   echo "Adding localised PHPUnit config to Drupal webroot"
@@ -20,43 +16,4 @@ if [ ! -f "${DRUPAL_ROOT}/core/phpunit.xml" ]; then
   sed -i -e "s|<!-- <env name=\"SYMFONY_DEPRECATIONS_HELPER\" value=\"disabled\"/> -->|<env name=\"SYMFONY_DEPRECATIONS_HELPER\" value=\"disabled\"/>|g" $DRUPAL_ROOT/core/phpunit.xml
   # Set the base URL for kernel tests.
   sed -i -e "s|name=\"SIMPLETEST_BASE_URL\" value=\"\"|name=\"SIMPLETEST_BASE_URL\" value=\"http:\/\/${LANDO_APP_NAME}.${LANDO_DOMAIN}\"|g" $DRUPAL_ROOT/core/phpunit.xml
-fi
-
-# Add yarn/nodejs packages to allow functional testing on this service.
-if [ ! -f "$NODE_YARN_INSTALLED" ]; then
-  # Update packages and add gnupg and https for apt to fetch yarn packages.
-  apt update
-  apt install -y gnupg apt-transport-https
-  # Add yarn deb repo.
-  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-  apt update
-  apt install -y yarn
-  # Add and fetch up to date nodejs to allow yarn to run correctly.
-  curl -sL https://deb.nodesource.com/setup_14.x | bash -
-  apt install -y nodejs
-
-  # Copy Drupal .env.example file, inject Lando vars and set in place for use by Nightwatch conf.
-  cat $DRUPAL_ROOT/core/.env.example | sed -e "s|\(^DRUPAL_TEST_BASE_URL\)\(.\+\)|\1=http:\/\/${LANDO_APP_NAME}.${LANDO_DOMAIN}|g" > $DRUPAL_ROOT/core/.env
-  # Alter a few more variables.
-  sed -i -e "s|\(#\)\(DRUPAL_NIGHTWATCH_SEARCH_DIRECTORY\)=|\2=../|g" $DRUPAL_ROOT/core/.env
-  sed -i -e "s|sqlite:\/\/localhost\/sites\/default\/files/db.sqlite|${DB_DRIVER}://${DB_USER}:${DB_PASS}@${DB_HOST}/${DB_NAME}|g" $DRUPAL_ROOT/core/.env
-  sed -i -e "s|\(^DRUPAL_TEST_WEBDRIVER_HOSTNAME\)=localhost|\1=chromedriver|g" $DRUPAL_ROOT/core/.env
-  sed -i -e "s|^DRUPAL_TEST_CHROMEDRIVER_AUTOSTART=true|DRUPAL_TEST_CHROMEDRIVER_AUTOSTART=false|g" $DRUPAL_ROOT/core/.env
-  sed -i -e "s|\(#\)\(DRUPAL_TEST_WEBDRIVER_CHROME_ARGS\)=|\2=\"--disable-gpu --headless --no-sandbox\"|g" $DRUPAL_ROOT/core/.env
-  sed -i -e "s|\(^DRUPAL_NIGHTWATCH_OUTPUT\)=reports/nightwatch|\1=/app/.lando/exports/nightwatch-reports|g" $DRUPAL_ROOT/core/.env
-
-  # Fetch and install node packages if they're not already present.
-  if [ ! -d "${DRUPAL_ROOT}/core/node_modules" ]; then
-    cd $DRUPAL_ROOT/core && yarn install
-  fi
-
-  # Install any known extra npm packges for, eg: migrations.
-    if [ ! -d "${DRUPAL_CUSTOM_CODE}/node_modules" ]; then
-    cd $DRUPAL_CUSTOM_CODE
-    npm install
-  fi
-
-  touch $NODE_YARN_INSTALLED
-
 fi


### PR DESCRIPTION
- Means no more 20 seconds, followed by 60 second warning message on every application rebuild.
- Pruned away yarn. Can't see anything we use that exclusively relies on that and isn't compatible with npm