### PR TITLE
D8UN-2695 & D8UN-2696

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -198,7 +198,9 @@
                 "Expand menu_tree field sizes": "https://www.drupal.org/files/issues/2022-10-11/3106205-36.patch",
                 "Fix TypeError when adding book page": "https://www.drupal.org/files/issues/2023-10-02/book_typeerror-3391063-1.patch",
                 "Allow authors without manage book privleges permission to save unpublished versions of published nodes": "https://www.drupal.org/files/issues/2022-12-14/2918537-92.patch",
-                "Fix getSetting() error on translated migrations": "https://www.drupal.org/files/issues/2018-07-08/2984460-3.patch"
+                "Fix getSetting() error on translated migrations": "https://www.drupal.org/files/issues/2018-07-08/2984460-3.patch",
+                "Fix for reference error on unpublished nodes on Entity Queue": "https://www.drupal.org/files/issues/2024-04-16/2845144-95.patch"
+
             },
             "drupal/easy_install": {
                 "Handle missing core version": "https://www.drupal.org/files/issues/2019-12-19/easy_install_core_version-3101883-0.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7812575eb1ba6189bda6ea16cb0fc7ff",
+    "content-hash": "4432cd45aaf474b2fa2288a9e4c456f1",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
Patch applied to fix the entity queue reference error when unpublished nodes exist on the queue
Patch will fix both tickets and works with core 10.2.5.