### PR TITLE
D8UN-2765

### DIFF
--- a/project/config/uregni/config/block.block.publicationdateconsultation.yml
+++ b/project/config/uregni/config/block.block.publicationdateconsultation.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - facets.facet.publication_date_consultation
   module:
+    - block_visibility_groups
     - facets
     - system
   theme:
@@ -20,10 +21,15 @@ settings:
   label: 'Publication date'
   label_display: visible
   provider: facets
+  context_mapping: {  }
   block_id: publicationdateconsultation
 visibility:
   request_path:
     id: request_path
     negate: false
     context_mapping: {  }
-    pages: "/consultations\r\n/consultations/topic/*\r\n/consultations/date/*"
+    pages: "/consultations\r\n/consultations/topic/*\r\n/consultations/date/*\r\n/consultations/status/*"
+  condition_group:
+    id: condition_group
+    negate: false
+    block_visibility_group: ''

--- a/project/config/uregni/config/block.block.topicconsultation.yml
+++ b/project/config/uregni/config/block.block.topicconsultation.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - facets.facet.topic_consultation
   module:
+    - block_visibility_groups
     - facets
     - system
   theme:
@@ -20,10 +21,15 @@ settings:
   label: Topic
   label_display: visible
   provider: facets
+  context_mapping: {  }
   block_id: topicconsultation
 visibility:
   request_path:
     id: request_path
     negate: false
     context_mapping: {  }
-    pages: "/consultations\r\n/consultations/topic/*\r\n/consultations/date/*"
+    pages: "/consultations\r\n/consultations/topic/*\r\n/consultations/date/*\r\n/consultations/status/*"
+  condition_group:
+    id: condition_group
+    negate: false
+    block_visibility_group: ''

--- a/project/config/uregni/config/block.block.uregni_theme_status.yml
+++ b/project/config/uregni/config/block.block.uregni_theme_status.yml
@@ -1,0 +1,34 @@
+uuid: c38ede66-8a4f-41e5-b707-c7c3f26f517e
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.status
+  module:
+    - block_visibility_groups
+    - facets
+    - system
+  theme:
+    - uregni_theme
+id: uregni_theme_status
+theme: uregni_theme
+region: search_facets
+weight: 0
+provider: null
+plugin: 'facet_block:status'
+settings:
+  id: 'facet_block:status'
+  label: Status
+  label_display: visible
+  provider: facets
+  context_mapping: {  }
+  block_id: uregni_theme_status
+visibility:
+  condition_group:
+    id: condition_group
+    negate: false
+    block_visibility_group: ''
+  request_path:
+    id: request_path
+    negate: false
+    pages: "/consultations\r\n/consultations/topic/*\r\n/consultations/date/*\r\n/consultations/status/*"

--- a/project/config/uregni/config/core.entity_form_display.node.consultation.default.yml
+++ b/project/config/uregni/config/core.entity_form_display.node.consultation.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.consultation.body
     - field.field.node.consultation.field_attachment
     - field.field.node.consultation.field_consultation_dates
+    - field.field.node.consultation.field_current_status
     - field.field.node.consultation.field_email_address
     - field.field.node.consultation.field_meta_tags
     - field.field.node.consultation.field_postal
@@ -92,6 +93,7 @@ content:
     region: content
     settings:
       sidebar: true
+      use_details: true
     third_party_settings: {  }
   field_postal:
     type: string_textarea
@@ -213,4 +215,5 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_current_status: true

--- a/project/config/uregni/config/core.entity_view_display.node.consultation.default.yml
+++ b/project/config/uregni/config/core.entity_view_display.node.consultation.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.consultation.body
     - field.field.node.consultation.field_attachment
     - field.field.node.consultation.field_consultation_dates
+    - field.field.node.consultation.field_current_status
     - field.field.node.consultation.field_email_address
     - field.field.node.consultation.field_meta_tags
     - field.field.node.consultation.field_postal
@@ -85,6 +86,7 @@ content:
     region: content
 hidden:
   content_moderation_control: true
+  field_current_status: true
   field_meta_tags: true
   field_publication_topic: true
   langcode: true

--- a/project/config/uregni/config/core.entity_view_display.node.consultation.diff.yml
+++ b/project/config/uregni/config/core.entity_view_display.node.consultation.diff.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.consultation.body
     - field.field.node.consultation.field_attachment
     - field.field.node.consultation.field_consultation_dates
+    - field.field.node.consultation.field_current_status
     - field.field.node.consultation.field_email_address
     - field.field.node.consultation.field_meta_tags
     - field.field.node.consultation.field_postal
@@ -30,11 +31,12 @@ third_party_settings:
     group_additional_content_details:
       children:
         - field_publication_topic
+        - field_current_status
         - field_meta_tags
       label: 'Additional content details'
       parent_name: ''
       region: content
-      weight: 6
+      weight: 7
       format_type: html_element
       format_settings:
         classes: field-collection
@@ -98,6 +100,14 @@ content:
     third_party_settings: {  }
     weight: 1
     region: content
+  field_current_status:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 11
+    region: content
   field_email_address:
     type: email_mailto
     label: visually_hidden
@@ -110,7 +120,7 @@ content:
     label: inline
     settings: {  }
     third_party_settings: {  }
-    weight: 11
+    weight: 12
     region: content
   field_postal:
     type: basic_string

--- a/project/config/uregni/config/core.entity_view_display.node.consultation.full.yml
+++ b/project/config/uregni/config/core.entity_view_display.node.consultation.full.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.consultation.body
     - field.field.node.consultation.field_attachment
     - field.field.node.consultation.field_consultation_dates
+    - field.field.node.consultation.field_current_status
     - field.field.node.consultation.field_email_address
     - field.field.node.consultation.field_meta_tags
     - field.field.node.consultation.field_postal
@@ -110,6 +111,7 @@ content:
     region: content
 hidden:
   content_moderation_control: true
+  field_current_status: true
   field_meta_tags: true
   field_publication_topic: true
   langcode: true

--- a/project/config/uregni/config/core.entity_view_display.node.consultation.search_result.yml
+++ b/project/config/uregni/config/core.entity_view_display.node.consultation.search_result.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.consultation.body
     - field.field.node.consultation.field_attachment
     - field.field.node.consultation.field_consultation_dates
+    - field.field.node.consultation.field_current_status
     - field.field.node.consultation.field_email_address
     - field.field.node.consultation.field_meta_tags
     - field.field.node.consultation.field_postal
@@ -53,6 +54,7 @@ hidden:
   body: true
   content_moderation_control: true
   field_attachment: true
+  field_current_status: true
   field_email_address: true
   field_meta_tags: true
   field_postal: true

--- a/project/config/uregni/config/core.entity_view_display.node.consultation.search_result.yml
+++ b/project/config/uregni/config/core.entity_view_display.node.consultation.search_result.yml
@@ -17,7 +17,6 @@ dependencies:
     - node.type.consultation
   module:
     - datetime
-    - datetime_range
     - layout_builder
     - user
 third_party_settings:
@@ -31,13 +30,11 @@ targetEntityType: node
 bundle: consultation
 mode: search_result
 content:
-  field_consultation_dates:
-    type: daterange_default
+  field_current_status:
+    type: string
     label: hidden
     settings:
-      timezone_override: ''
-      format_type: medium
-      separator: '-'
+      link_to_entity: false
     third_party_settings: {  }
     weight: 1
     region: content
@@ -54,7 +51,7 @@ hidden:
   body: true
   content_moderation_control: true
   field_attachment: true
-  field_current_status: true
+  field_consultation_dates: true
   field_email_address: true
   field_meta_tags: true
   field_postal: true

--- a/project/config/uregni/config/core.entity_view_display.node.consultation.teaser.yml
+++ b/project/config/uregni/config/core.entity_view_display.node.consultation.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.consultation.body
     - field.field.node.consultation.field_attachment
     - field.field.node.consultation.field_consultation_dates
+    - field.field.node.consultation.field_current_status
     - field.field.node.consultation.field_email_address
     - field.field.node.consultation.field_meta_tags
     - field.field.node.consultation.field_postal
@@ -41,6 +42,7 @@ hidden:
   content_moderation_control: true
   field_attachment: true
   field_consultation_dates: true
+  field_current_status: true
   field_email_address: true
   field_meta_tags: true
   field_postal: true

--- a/project/config/uregni/config/core.extension.yml
+++ b/project/config/uregni/config/core.extension.yml
@@ -148,6 +148,7 @@ module:
   unity_landing_pages: 0
   unity_search_pages: 0
   uregni_breadcrumbs: 0
+  uregni_consultations: 0
   user: 0
   views_custom_cache_tag: 0
   webform: 0

--- a/project/config/uregni/config/facets.facet.status.yml
+++ b/project/config/uregni/config/facets.facet.status.yml
@@ -1,0 +1,77 @@
+uuid: 5fe05019-20c3-49ed-9387-8110b01c101b
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.consultations
+    - views.view.consultations_search
+  module:
+    - facets_pretty_paths
+    - search_api
+third_party_settings:
+  facets_pretty_paths:
+    coder: default_coder
+id: status
+name: Status
+weight: 0
+min_count: 1
+missing: false
+missing_label: others
+url_alias: status
+facet_source_id: 'search_api:views_page__consultations_search__consultations_search_page'
+field_identifier: field_current_status
+query_operator: and
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+widget:
+  type: links
+  config:
+    show_numbers: true
+    soft_limit: 20
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show fewer'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: true
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  list_item:
+    processor_id: list_item
+    weights:
+      build: 5
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/project/config/uregni/config/field.field.node.consultation.field_current_status.yml
+++ b/project/config/uregni/config/field.field.node.consultation.field_current_status.yml
@@ -1,0 +1,19 @@
+uuid: 268c1ddb-53d0-4e79-87da-ec3843f31ecd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_current_status
+    - node.type.consultation
+id: node.consultation.field_current_status
+field_name: field_current_status
+entity_type: node
+bundle: consultation
+label: 'Current Status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/project/config/uregni/config/field.storage.node.field_current_status.yml
+++ b/project/config/uregni/config/field.storage.node.field_current_status.yml
@@ -1,0 +1,21 @@
+uuid: 4ff4d7e7-a6f4-4a5c-bd4e-fd8082d0b254
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_current_status
+field_name: field_current_status
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/project/config/uregni/config/search_api.index.consultations.yml
+++ b/project/config/uregni/config/search_api.index.consultations.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.body
     - field.storage.node.field_consultation_dates
+    - field.storage.node.field_current_status
     - field.storage.node.field_published_date
     - field.storage.node.field_publication_topic
     - search_api.server.solr_default
@@ -82,6 +83,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_consultation_dates
+  field_current_status:
+    label: 'Current Status'
+    datasource_id: 'entity:node'
+    property_path: field_current_status
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_current_status
   field_publication_topic:
     label: Topic
     datasource_id: 'entity:node'
@@ -155,13 +164,17 @@ datasource_settings:
 processor_settings:
   add_url: {  }
   aggregated_field: {  }
+  auto_aggregated_fulltext_field: {  }
+  custom_value: {  }
   entity_status: {  }
+  entity_type: {  }
   highlight:
     weights:
       postprocess_query: 0
     prefix: '<strong>'
     suffix: '</strong>'
     excerpt: true
+    excerpt_always: false
     excerpt_length: 256
     exclude_fields: {  }
     highlight: always
@@ -194,4 +207,5 @@ tracker_settings:
 options:
   cron_limit: 50
   index_directly: true
+  track_changes_in_references: true
 server: solr_default

--- a/project/config/uregni/config/ultimate_cron.job.uregni_consultations_cron.yml
+++ b/project/config/uregni/config/ultimate_cron.job.uregni_consultations_cron.yml
@@ -1,0 +1,17 @@
+uuid: 53bd46cc-e710-4a90-a5d0-c283752e0af8
+langcode: en
+status: true
+dependencies:
+  module:
+    - uregni_consultations
+title: 'Default cron handler'
+id: uregni_consultations_cron
+weight: 0
+module: uregni_consultations
+callback: uregni_consultations_cron
+scheduler:
+  id: simple
+launcher:
+  id: serial
+logger:
+  id: database

--- a/project/config/uregni/config/ultimate_cron.job.uregni_consultations_cron.yml
+++ b/project/config/uregni/config/ultimate_cron.job.uregni_consultations_cron.yml
@@ -11,7 +11,19 @@ module: uregni_consultations
 callback: uregni_consultations_cron
 scheduler:
   id: simple
+  configuration:
+    rules:
+      - '0+@ 0 * * *'
 launcher:
   id: serial
+  configuration:
+    timeouts:
+      lock_timeout: 3600
+    launcher:
+      thread: 0
 logger:
   id: database
+  configuration:
+    method: '3'
+    expire: 1209600
+    retain: 1000

--- a/project/config/uregni/config/views.view.consultations_search.yml
+++ b/project/config/uregni/config/views.view.consultations_search.yml
@@ -403,6 +403,7 @@ display:
         - 'config:field.storage.node.field_consultation_dates'
         - 'config:field.storage.node.field_published_date'
         - 'config:search_api.index.consultations'
+        - 'search_api_list:consultations'
   consultations_search_page:
     id: consultations_search_page
     display_title: Page
@@ -423,7 +424,7 @@ display:
         weight: -43
         menu_name: main
     cache_metadata:
-      max-age: -1
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -431,6 +432,10 @@ display:
         - url.query_args
         - 'user.node_grants:view'
       tags:
+        - 'config:facets.facet.publication_date_consultation'
+        - 'config:facets.facet.status'
+        - 'config:facets.facet.topic_consultation'
         - 'config:field.storage.node.field_consultation_dates'
         - 'config:field.storage.node.field_published_date'
         - 'config:search_api.index.consultations'
+        - 'search_api_list:consultations'

--- a/project/config/uregni/local/ultimate_cron.job.dblog_cron.yml
+++ b/project/config/uregni/local/ultimate_cron.job.dblog_cron.yml
@@ -1,0 +1,17 @@
+uuid: 00e1f826-ac49-44fb-8dc7-28daa7f4934c
+langcode: en
+status: true
+dependencies:
+  module:
+    - dblog
+title: 'Remove expired log messages and flood control events'
+id: dblog_cron
+weight: 0
+module: dblog
+callback: dblog_cron
+scheduler:
+  id: simple
+launcher:
+  id: serial
+logger:
+  id: database

--- a/project/sites/uregni/modules/custom/uregni_consultations/uregni_consultations.info.yml
+++ b/project/sites/uregni/modules/custom/uregni_consultations/uregni_consultations.info.yml
@@ -1,0 +1,5 @@
+name: 'Uregni Consultation date field'
+type: module
+description: 'Consultation customisations'
+core_version_requirement: 8.x || ^9 || ^10
+package: 'Uregni'

--- a/project/sites/uregni/modules/custom/uregni_consultations/uregni_consultations.module
+++ b/project/sites/uregni/modules/custom/uregni_consultations/uregni_consultations.module
@@ -5,13 +5,8 @@
  * Contains uregni_consultations.module.
  */
 
-use Drupal\Core\Database\Database;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\node\NodeInterface;
-use Drupal\views\ViewExecutable;
 use Drupal\Core\Datetime\DrupalDateTime;
-use Drupal\Core\Render\Markup;
 
 /**
  * Implements hook_entity_presave().
@@ -19,7 +14,7 @@ use Drupal\Core\Render\Markup;
  */
 function uregni_consultations_entity_presave(EntityInterface $entity)
 {
-
+  // Only run this code on consultations
   if ($entity->bundle() == 'consultation') {
 
   // Get the current time to gauge consultation start and end dates off.
@@ -35,7 +30,7 @@ function uregni_consultations_entity_presave(EntityInterface $entity)
   $consultation_end_date_date_time = new DrupalDateTime($consultation_end_date, 'UTC');
   $consultation_end_date_timestamp = $consultation_end_date_date_time->getTimestamp();
 
-
+    // Calculating date range field and outputting the relative label into the current_status field.
     if ($current_time > $consultation_start_date_timestamp && $current_time <= $consultation_end_date_timestamp) {
       $entity->field_current_status->value = "Current";
     }
@@ -45,10 +40,52 @@ function uregni_consultations_entity_presave(EntityInterface $entity)
     else {
       $entity->field_current_status->value = "Closed";
     }
-
-    \Drupal::logger('uregni_consultations')->notice(t("Just a test message"));
   }
 }
+
+/**
+ * Implements hook_cron().
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ */
+function uregni_consultations_cron()
+{
+  // Retrieve all consultations.
+  $consultations = \Drupal::entityTypeManager()->getStorage('node')
+    ->loadByProperties([
+      'type' => 'consultation'
+    ]);
+
+  // Loop through all consultations
+  foreach ($consultations as $consultation) {
+
+    // Get the current time to gauge consultation start and end dates off.
+    $current_time = \Drupal::time()->getCurrentTime();
+
+    // Convert consultation start date to a timestamp.
+    $consultation_start_date = $consultation->get('field_consultation_dates')->value;
+    $consultation_start_date_date_time = new DrupalDateTime($consultation_start_date, 'UTC');
+    $consultation_start_date_timestamp = $consultation_start_date_date_time->getTimestamp();
+
+    // Convert consultation end date to a timestamp.
+    $consultation_end_date = $consultation->get('field_consultation_dates')->end_value;
+    $consultation_end_date_date_time = new DrupalDateTime($consultation_end_date, 'UTC');
+    $consultation_end_date_timestamp = $consultation_end_date_date_time->getTimestamp();
+
+    // Calculating date range field and outputting the relative label into the current_status field.
+    if ($current_time > $consultation_start_date_timestamp && $current_time <= $consultation_end_date_timestamp) {
+      $consultation->field_current_status->value = "Current";
+
+    } elseif ($current_time < $consultation_start_date_timestamp && $current_time <= $consultation_end_date_timestamp) {
+      $consultation->field_current_status->value = "Upcoming";
+
+    } else {
+      $consultation->field_current_status->value = "Closed";
+    }
+
+    $consultation->save();
+  }
+}
+
 
 
 

--- a/project/sites/uregni/modules/custom/uregni_consultations/uregni_consultations.module
+++ b/project/sites/uregni/modules/custom/uregni_consultations/uregni_consultations.module
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @file
+ * Contains uregni_consultations.module.
+ */
+
+use Drupal\Core\Database\Database;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\node\NodeInterface;
+use Drupal\views\ViewExecutable;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Render\Markup;
+
+/**
+ * Implements hook_entity_presave().
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ */
+function uregni_consultations_entity_presave(EntityInterface $entity)
+{
+
+  if ($entity->bundle() == 'consultation') {
+
+  // Get the current time to gauge consultation start and end dates off.
+  $current_time = \Drupal::time()->getCurrentTime();
+
+  // Convert consultation start date to a timestamp.
+  $consultation_start_date = $entity->get('field_consultation_dates')->value;
+  $consultation_start_date_date_time = new DrupalDateTime($consultation_start_date, 'UTC');
+  $consultation_start_date_timestamp = $consultation_start_date_date_time->getTimestamp();
+
+  // Convert consultation end date to a timestamp.
+  $consultation_end_date = $entity->get('field_consultation_dates')->end_value;
+  $consultation_end_date_date_time = new DrupalDateTime($consultation_end_date, 'UTC');
+  $consultation_end_date_timestamp = $consultation_end_date_date_time->getTimestamp();
+
+
+    if ($current_time > $consultation_start_date_timestamp && $current_time <= $consultation_end_date_timestamp) {
+      $entity->field_current_status->value = "Current";
+    }
+    elseif ($current_time < $consultation_start_date_timestamp && $current_time <= $consultation_end_date_timestamp) {
+      $entity->field_current_status->value = "Upcoming";
+    }
+    else {
+      $entity->field_current_status->value = "Closed";
+    }
+
+    \Drupal::logger('uregni_consultations')->notice(t("Just a test message"));
+  }
+}
+
+
+

--- a/project/sites/uregni/modules/custom/uregni_consultations/uregni_consultations.module
+++ b/project/sites/uregni/modules/custom/uregni_consultations/uregni_consultations.module
@@ -17,29 +17,10 @@ function uregni_consultations_entity_presave(EntityInterface $entity)
   // Only run this code on consultations
   if ($entity->bundle() == 'consultation') {
 
-  // Get the current time to gauge consultation start and end dates off.
-  $current_time = \Drupal::time()->getCurrentTime();
+    // Get the current time to gauge consultation start and end dates off.
+    $current_time = \Drupal::time()->getCurrentTime();
 
-  // Convert consultation start date to a timestamp.
-  $consultation_start_date = $entity->get('field_consultation_dates')->value;
-  $consultation_start_date_date_time = new DrupalDateTime($consultation_start_date, 'UTC');
-  $consultation_start_date_timestamp = $consultation_start_date_date_time->getTimestamp();
-
-  // Convert consultation end date to a timestamp.
-  $consultation_end_date = $entity->get('field_consultation_dates')->end_value;
-  $consultation_end_date_date_time = new DrupalDateTime($consultation_end_date, 'UTC');
-  $consultation_end_date_timestamp = $consultation_end_date_date_time->getTimestamp();
-
-    // Calculating date range field and outputting the relative label into the current_status field.
-    if ($current_time > $consultation_start_date_timestamp && $current_time <= $consultation_end_date_timestamp) {
-      $entity->field_current_status->value = "Current";
-    }
-    elseif ($current_time < $consultation_start_date_timestamp && $current_time <= $consultation_end_date_timestamp) {
-      $entity->field_current_status->value = "Upcoming";
-    }
-    else {
-      $entity->field_current_status->value = "Closed";
-    }
+    $entity = updateConsultationstatus($entity, $current_time);
   }
 }
 
@@ -55,37 +36,39 @@ function uregni_consultations_cron()
       'type' => 'consultation'
     ]);
 
+  // Get the current time to gauge consultation start and end dates off.
+  $current_time = \Drupal::time()->getCurrentTime();
+
   // Loop through all consultations
   foreach ($consultations as $consultation) {
 
-    // Get the current time to gauge consultation start and end dates off.
-    $current_time = \Drupal::time()->getCurrentTime();
-
-    // Convert consultation start date to a timestamp.
-    $consultation_start_date = $consultation->get('field_consultation_dates')->value;
-    $consultation_start_date_date_time = new DrupalDateTime($consultation_start_date, 'UTC');
-    $consultation_start_date_timestamp = $consultation_start_date_date_time->getTimestamp();
-
-    // Convert consultation end date to a timestamp.
-    $consultation_end_date = $consultation->get('field_consultation_dates')->end_value;
-    $consultation_end_date_date_time = new DrupalDateTime($consultation_end_date, 'UTC');
-    $consultation_end_date_timestamp = $consultation_end_date_date_time->getTimestamp();
-
-    // Calculating date range field and outputting the relative label into the current_status field.
-    if ($current_time > $consultation_start_date_timestamp && $current_time <= $consultation_end_date_timestamp) {
-      $consultation->field_current_status->value = "Current";
-
-    } elseif ($current_time < $consultation_start_date_timestamp && $current_time <= $consultation_end_date_timestamp) {
-      $consultation->field_current_status->value = "Upcoming";
-
-    } else {
-      $consultation->field_current_status->value = "Closed";
-    }
+    $consultation = updateConsultationStatus($consultation, $current_time);
 
     $consultation->save();
   }
 }
 
+function updateConsultationStatus($consultation, $current_time) {
 
+  // Convert consultation start date to a timestamp.
+  $consultation_start_date = $consultation->get('field_consultation_dates')->value;
+  $consultation_start_date_date_time = new DrupalDateTime($consultation_start_date, 'UTC');
+  $consultation_start_date_timestamp = $consultation_start_date_date_time->getTimestamp();
 
+  // Convert consultation end date to a timestamp.
+  $consultation_end_date = $consultation->get('field_consultation_dates')->end_value;
+  $consultation_end_date_date_time = new DrupalDateTime($consultation_end_date, 'UTC');
+  $consultation_end_date_timestamp = $consultation_end_date_date_time->getTimestamp();
 
+  // Calculating date range field and outputting the relative label into the current_status field.
+  if ($current_time > $consultation_start_date_timestamp && $current_time <= $consultation_end_date_timestamp) {
+    $consultation->field_current_status->value = "Current";
+
+  } elseif ($current_time < $consultation_start_date_timestamp && $current_time <= $consultation_end_date_timestamp) {
+    $consultation->field_current_status->value = "Upcoming";
+
+  } else {
+    $consultation->field_current_status->value = "Closed";
+  }
+  return $consultation;
+}

--- a/project/sites/uregni/modules/custom/uregni_consultations/uregni_consultations.module
+++ b/project/sites/uregni/modules/custom/uregni_consultations/uregni_consultations.module
@@ -20,7 +20,7 @@ function uregni_consultations_entity_presave(EntityInterface $entity)
     // Get the current time to gauge consultation start and end dates off.
     $current_time = \Drupal::time()->getCurrentTime();
 
-    $entity = updateConsultationstatus($entity, $current_time);
+    $entity = updateConsultationStatus($entity, $current_time);
   }
 }
 

--- a/project/sites/uregni/themes/uregni_theme/templates/content/node--consultation--search-result.html.twig
+++ b/project/sites/uregni/themes/uregni_theme/templates/content/node--consultation--search-result.html.twig
@@ -72,5 +72,5 @@
 </h3>
 <p class="meta">
   {{ content.field_published_date }}
-  <span class="metaListItem">{{ content.field_consultation_dates.status }}</span>
+  <span class="metaListItem">{{ content.field_current_status }}</span>
 </p>

--- a/project/sites/uregni/themes/uregni_theme/templates/field/field--node--field-current-status--search-result--consultation.html.twig
+++ b/project/sites/uregni/themes/uregni_theme/templates/field/field--node--field-current-status--search-result--consultation.html.twig
@@ -1,0 +1,41 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{% for item in items %}
+  <span>{{ item.content }}</span>
+{% endfor %}

--- a/project/sites/uregni/themes/uregni_theme/uregni_theme.theme
+++ b/project/sites/uregni/themes/uregni_theme/uregni_theme.theme
@@ -39,8 +39,12 @@ function uregni_theme_preprocess_node(array &$variables) {
     if ($current_time > $consultation_start_date_timestamp && $current_time <= $consultation_end_date_timestamp) {
       $variables['consultation_in_progress'] = TRUE;
       // Text to display if the consultation is open or closed. Used in the search result view mode only.
-      $output = t('Open');
+      $output = t('Current');
     }
+    elseif ($current_time < $consultation_start_date_timestamp && $current_time <= $consultation_end_date_timestamp) {
+      // Text to display if the consultation is open or closed. Used in the search result view mode only.
+      $output = t('Upcoming');
+     }
     else {
       $output = t('Closed');
     }
@@ -49,7 +53,6 @@ function uregni_theme_preprocess_node(array &$variables) {
       // Replace the dates with text as to whether open or closed consultation.
       $variables['content']['field_consultation_dates']['status'] = Markup::create($output);
     }
-
   }
 }
 

--- a/project/sites/uregni/themes/uregni_theme/uregni_theme.theme
+++ b/project/sites/uregni/themes/uregni_theme/uregni_theme.theme
@@ -12,31 +12,18 @@ use Drupal\node\Entity\Node;
 /**
  * Implements hook_preprocess_node().
  */
+ 
 function uregni_theme_preprocess_node(array &$variables) {
   // Only use this code for consultations content type.
   if ($variables['node']->getType() === 'consultation') {
 
-    // Get the current time to gauge consultation start and end dates off.
-    $current_time = \Drupal::time()->getCurrentTime();
-
-    // Convert consultation start date to a timestamp.
-    $consultation_start_date = $variables['node']->get('field_consultation_dates')->value;
-    $consultation_start_date_date_time = new DrupalDateTime($consultation_start_date, 'UTC');
-    $consultation_start_date_timestamp = $consultation_start_date_date_time->getTimestamp();
-
-    // Convert consultation end date to a timestamp.
-    $consultation_end_date = $variables['node']->get('field_consultation_dates')->end_value;
-    $consultation_end_date_date_time = new DrupalDateTime($consultation_end_date, 'UTC');
-    $consultation_end_date_timestamp = $consultation_end_date_date_time->getTimestamp();
-
-    // Set a variable to be used in the twig template for the consultation end date time.
-    $variables['consultation_end_time'] = date('H:i', $consultation_end_date_timestamp);
+    $status = $variables['node']->get('field_current_status')->value;
 
     // Set a variable to be used in the twig template for the ways to respond fieldgroup, initially set to 0.
     $variables['consultation_in_progress'] = FALSE;
 
     // If the consultation started before and is ending after today's date then show the contact information.
-    if ($current_time > $consultation_start_date_timestamp && $current_time <= $consultation_end_date_timestamp) {
+    if ($status == "Current") {
       $variables['consultation_in_progress'] = TRUE;
     }
   }

--- a/project/sites/uregni/themes/uregni_theme/uregni_theme.theme
+++ b/project/sites/uregni/themes/uregni_theme/uregni_theme.theme
@@ -38,20 +38,6 @@ function uregni_theme_preprocess_node(array &$variables) {
     // If the consultation started before and is ending after today's date then show the contact information.
     if ($current_time > $consultation_start_date_timestamp && $current_time <= $consultation_end_date_timestamp) {
       $variables['consultation_in_progress'] = TRUE;
-      // Text to display if the consultation is open or closed. Used in the search result view mode only.
-      $output = t('Current');
-    }
-    elseif ($current_time < $consultation_start_date_timestamp && $current_time <= $consultation_end_date_timestamp) {
-      // Text to display if the consultation is open or closed. Used in the search result view mode only.
-      $output = t('Upcoming');
-     }
-    else {
-      $output = t('Closed');
-    }
-
-    if ($variables['view_mode'] == 'search_result') {
-      // Replace the dates with text as to whether open or closed consultation.
-      $variables['content']['field_consultation_dates']['status'] = Markup::create($output);
     }
   }
 }


### PR DESCRIPTION
- Building a custom module to programmatically input status label into a field on the consultation content type
- Cron task which runs to overwrite field with correct status when time passes
- Facet and block created to allow users to filter consultations by status
- Status field hidden from form view so authors can't edit it manually.