### PR TITLE
URL Pattern for Vacancy

### DIFF
--- a/project/config/uregni/config/pathauto.pattern.basic_page_pattern.yml
+++ b/project/config/uregni/config/pathauto.pattern.basic_page_pattern.yml
@@ -9,15 +9,14 @@ label: 'Basic page pattern'
 type: 'canonical_entities:node'
 pattern: '[node:title]'
 selection_criteria:
-  7bf6f2ea-8059-406a-8239-29c132d37229:
+  b9a60282-f669-41af-b331-a53521739e73:
     id: 'entity_bundle:node'
     negate: false
-    uuid: 7bf6f2ea-8059-406a-8239-29c132d37229
+    uuid: b9a60282-f669-41af-b331-a53521739e73
     context_mapping:
       node: node
     bundles:
       page: page
-      vacancy: vacancy
       webform: webform
 selection_logic: and
 weight: -5

--- a/project/config/uregni/config/pathauto.pattern.vacancy.yml
+++ b/project/config/uregni/config/pathauto.pattern.vacancy.yml
@@ -1,0 +1,22 @@
+uuid: 3c2ad428-3f4d-443b-b82c-39ad04da75d5
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: vacancy
+label: 'Vacancy pattern'
+type: 'canonical_entities:node'
+pattern: 'vacancy/[node:title]'
+selection_criteria:
+  a2e68b33-4e66-467b-b60a-4c7aca586d79:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: a2e68b33-4e66-467b-b60a-4c7aca586d79
+    context_mapping:
+      node: node
+    bundles:
+      vacancy: vacancy
+selection_logic: and
+weight: 0
+relationships: {  }

--- a/project/config/uregni/config/pathauto.pattern.vacancy_pattern.yml
+++ b/project/config/uregni/config/pathauto.pattern.vacancy_pattern.yml
@@ -1,18 +1,18 @@
-uuid: 3c2ad428-3f4d-443b-b82c-39ad04da75d5
+uuid: 48f1dd97-9aff-444a-a1b9-dfa319cf64ce
 langcode: en
 status: true
 dependencies:
   module:
     - node
-id: vacancy
+id: vacancy_pattern
 label: 'Vacancy pattern'
 type: 'canonical_entities:node'
 pattern: 'vacancy/[node:title]'
 selection_criteria:
-  a2e68b33-4e66-467b-b60a-4c7aca586d79:
+  83a0f332-669d-4fbf-84f3-8dc2e29b5cf8:
     id: 'entity_bundle:node'
     negate: false
-    uuid: a2e68b33-4e66-467b-b60a-4c7aca586d79
+    uuid: 83a0f332-669d-4fbf-84f3-8dc2e29b5cf8
     context_mapping:
       node: node
     bundles:


### PR DESCRIPTION
- Bug found when adding vacancy content types - if 'admin' or 'administrive' was in the URL it would cause forbidden error. - With /vacancy/title pattern, issue is solved.