### PR TITLE
Centralised CI config improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             wget \
               --header="Cache-Control: no-cache" \
               --header="Pragma: no-cache" \
-              "https://raw.githubusercontent.com/dof-dss/webdev-ci/development/shared-config.yml?nocache=$(date +%s)" \
+              "https://raw.githubusercontent.com/dof-dss/webdev-ci/main/shared-config.yml?nocache=$(date +%s)" \
               -O shared-config.yml
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,13 @@ jobs:
       - checkout
       - run:
           name: Download shared config
-          command: wget https://raw.githubusercontent.com/dof-dss/webdev-ci/development/shared-config.yml -O shared-config.yml
+          command: |
+            wget \
+              --header="Cache-Control: no-cache" \
+              --header="Pragma: no-cache" \
+              "https://raw.githubusercontent.com/dof-dss/webdev-ci/main/shared-config.yml?nocache=$(date +%s)" \
+              -O shared-config.yml
+
       - run:
           name: Combine shared jobs and local workflows
           command: |
@@ -26,17 +32,19 @@ jobs:
             tail -n +2 .circleci/workflow-config.yml > workflows-only.yml
             # Concatenate shared jobs+commands with repo workflows
             cat shared-config.yml workflows-only.yml > full-config.yml
+
       - continuation/continue:
           configuration_path: full-config.yml
           parameters: |
             {
               "php_version": "8.3",
               "drupal_core_version": "10.4",
-              "node_version": "14.21.3",
-              "coding_standards_dirs": "${PROJECT_ROOT}/web/sites ${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/modules/origins ${PROJECT_ROOT}/web/themes/custom ${PROJECT_ROOT}/web/themes/origins ${PROJECT_ROOT}/web/profiles/unity ${PROJECT_ROOT}/web/profiles/origins",
-              "custom_code_dirs": "${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/themes/custom",
-              "deprecated_code_dirs": "${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/modules/origins",
+              "node_version: "18",
+              "coding_standards_dirs": "${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/modules/origins ${PROJECT_ROOT}/web/themes/custom",
+              "custom_code_dirs": "${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/modules/origins",
+              "deprecated_code_dirs": "${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/modules/origins ${PROJECT_ROOT}/web/themes/custom",
               "edge_branch": "edge",
               "edge_build_dofdss_packages": "dof-dss/nicsdru_unity_theme:dev-10.x-dev dof-dss/nicsdru_origins_modules:dev-10.x-dev dof-dss/nicsdru_unity_modules:dev-10.x-dev dof-dss/nicsdru_unity_profile:dev-10.x-dev",
-              "ssh_fingerprint": "e8:86:75:e8:35:15:07:a6:2d:a0:00:17:69:a1:42:84"
+              "ignore_dirs": "/web/themes/origins/node_modules,/web/themes/custom/nicsdru_unity_theme/node_modules",
+              "ssh_fingerprint": "65:4e:c7:ca:9f:c0:40:f7:16:2c:da:33:63:1d:90:12"
             }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
               "php_version": "8.3",
               "drupal_core_version": "10.5",
               "node_version": "18",
-              "coding_standards_dirs": "${PROJECT_ROOT}/web/sites ${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/modules/origins ${PROJECT_ROOT}/web/themes/custom ${PROJECT_ROOT}/web/themes/origins ${PROJECT_ROOT}/web/profiles/unity ${PROJECT_ROOT}/web/profiles/origins",
+              "coding_standards_dirs": "${PROJECT_ROOT}/web/sites ${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/modules/origins ${PROJECT_ROOT}/web/themes/custom ${PROJECT_ROOT}/web/profiles/unity ${PROJECT_ROOT}/web/profiles/origins",
               "custom_code_dirs": "${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/themes/custom",
               "deprecated_code_dirs": "${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/modules/origins ${PROJECT_ROOT}/web/themes/custom",
               "edge_branch": "edge",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,356 +1,42 @@
 version: 2.1
 
-# Default docker image.
-default_docker_image: &docker_image
-  docker:
-    - image: thecodingmachine/php:8.3-v4-apache
-      environment:
-        PLATFORM_REGION: "uk-1.platform.sh"
-        PROJECT_ROOT: "/home/docker/project"
-        PHP_EXTENSION_GD: 1
-        PHP_EXTENSIONS: "gd"
-        PHP_INI_MEMORY_LIMIT: -1
-        PHP_INI_MAX_EXECUTION_TIME: 600
-        PHP_INI_MAX_INPUT_TIME: 600
-        # git variables to avoid empty committer identity errors
-        EMAIL: "circleci@localhost"
-        GIT_COMMITTER_NAME: "Circle CI"
-        GIT_AUTHOR_NAME: "Circle CI"
-        EDGE_BUILD_BRANCH: "edge"
+setup: true
 
-# Re-usable commands.
-commands:
-  checkout_code:
-    description: "Handle composer access tokens, SSH key fingerprints and code checkout"
-    steps:
-      # Add SSH user key so we can access related repositories as part of our initial clone + composer install command.
-      - add_ssh_keys:
-          fingerprints:
-            - "e8:86:75:e8:35:15:07:a6:2d:a0:00:17:69:a1:42:84"
-      - checkout
-  composer_tasks:
-    description: "Validate and install dependencies using composer"
-    steps:
-      - run:
-          name: Validate composer.json and composer.lock file for consistency
-          command: composer validate --no-check-all --strict
-      - restore_cache:
-          keys:
-            - composer-{{ checksum "composer.lock" }}
-      - run:
-          name: Fetch dependencies with composer
-          command: |
-            composer install --no-interaction --optimize-autoloader
-      - save_cache:
-          key: composer-{{ checksum "composer.lock" }}
-          paths:
-            - $HOME/.composer/cache
-  composer_tasks__no_cache:
-    description: "Validate and install dependencies using composer"
-    steps:
-      - run:
-          name: Validate composer.json and composer.lock file for consistency
-          command: composer validate --no-check-all --strict
-      - run:
-          name: Fetch dependencies with composer
-          command: |
-            composer install --no-interaction --optimize-autoloader
-  composer_tasks__edge_packages:
-    description: "Switch dof-dss packages to HEAD on development branch"
-    steps:
-      - run:
-          name: Switch dof-dss packages to HEAD on development branch
-          command: |
-            composer require dof-dss/nicsdru_unity_theme:dev-10.x-dev \
-              dof-dss/nicsdru_origins_modules:dev-10.x-dev \
-              dof-dss/nicsdru_unity_modules:dev-10.x-dev \
-              dof-dss/nicsdru_unity_profile:dev-10.x-dev
-  install_psh_cli:
-    description: "Install the Platform.sh CLI tool"
-    steps:
-      - run:
-          name: Install the Platform.sh CLI tool
-          command: curl -sS https://platform.sh/cli/installer | php
-      - run:
-          name: Add platform cli tool to $PATH
-          command: echo 'export PATH="$HOME/"'.platformsh/bin':"$PATH"' >> $BASH_ENV
-  hosts_keyscan:
-    description: "Adds github.com to known hosts in container; for working locally."
-    steps:
-      - run:
-          name: Keyscan for hosts that require SSH access
-          command: |
-            mkdir -p ~/.ssh
-            ssh-keyscan -H github.com >> ~/.ssh/known_hosts
-            ssh-keyscan -H ssh.$PLATFORM_REGION >> ~/.ssh/known_hosts
-jobs:
-  # Tests the integrity of the build, stores the results in a workspace for re-use in later jobs.
-  build:
-    <<: *docker_image
-    steps:
-      - checkout_code
-      - composer_tasks
-      - persist_to_workspace:
-          root: ./
-          paths:
-            - ./
-
-  # Test for coding standards - will inherit the workspace/filesystem changes from build step, above.
-  coding_standards:
-    <<: *docker_image
-    steps:
-      - attach_workspace:
-          at: ./
-      - run:
-          name: PHPCS analysis
-          command: |
-            CHECK_DIRS="${PROJECT_ROOT}/web/sites"
-            CHECK_DIRS="${CHECK_DIRS} ${PROJECT_ROOT}/web/modules/custom"
-            CHECK_DIRS="${CHECK_DIRS} ${PROJECT_ROOT}/web/modules/origins"
-            CHECK_DIRS="${CHECK_DIRS} ${PROJECT_ROOT}/web/themes/custom"
-            CHECK_DIRS="${CHECK_DIRS} ${PROJECT_ROOT}/web/themes/origins"
-            CHECK_DIRS="${CHECK_DIRS} ${PROJECT_ROOT}/web/profiles/unity"
-            CHECK_DIRS="${CHECK_DIRS} ${PROJECT_ROOT}/web/profiles/origins"
-            ~/project/phpcs.sh ${PROJECT_ROOT} $CHECK_DIRS
-
-  # Test for deprecated code - will inherit the workspace/filesystem changes from build step, above.
-  deprecated_code:
-    <<: *docker_image
-    steps:
-      - attach_workspace:
-          at: ./
-      - run:
-          name: Deprecated code check
-          command: |
-            cd $PROJECT_ROOT
-            CHECK_DIRS="${PROJECT_ROOT}/web/modules/custom"
-            CHECK_DIRS="$CHECK_DIRS ${PROJECT_ROOT}/web/modules/origins"
-            vendor/bin/drupal-check $CHECK_DIRS
-
-  disallowed_functions:
-    <<: *docker_image
-    steps:
-      - attach_workspace:
-          at: ./
-      - run:
-          name: Check for disallowed function calls
-          command: |
-            CHECK_DIRS="${PROJECT_ROOT}/web/modules/custom"
-            CHECK_DIRS="$CHECK_DIRS ${PROJECT_ROOT}/web/modules/origins"
-            vendor/bin/phpstan analyse $CHECK_DIRS -c .circleci/phpstan.neon
-
-  check_illegal_updates:
-    <<: *docker_image
-    steps:
-      - attach_workspace:
-          at: ./
-      - hosts_keyscan
-      - run:
-          name: Check for updates made directly in this repo rather than in maestro-drupal-unity
-          command: |
-            git clone git@github.com:dof-dss/maestro-drupal-unity.git
-            echo "** Any failures in this section indicate that updates have been made directly in this repo "
-            echo "when they should have been made in https://github.com/dof-dss/maestro-drupal-unity and"
-            echo "pulled from the upstream repo using 'maestro pub' **"
-            echo "** checking composer.json  **"
-            diff maestro-drupal-unity/composer.json composer.json
-            echo "** checking composer.lock  **"
-            diff maestro-drupal-unity/composer.lock composer.lock
-            echo "** checking circleci/config.yml  **"
-            #diff maestro-drupal-unity/.circleci/config.yml .circleci/config.yml
-            echo "** checking platform.app.yaml **"
-            grep 'will be overwritten' .platform.app.yaml
-            echo "** checking site.settings.php  **"
-            diff maestro-drupal-unity/web/sites/site.settings.php web/sites/site.settings.php
-            echo "** checking sites.php  **"
-            diff maestro-drupal-unity/web/sites/sites.php web/sites/sites.php
-
-  # Nightly edge build
-  edge_build:
-    <<: *docker_image
-    environment:
-      # git variables to avoid empty committer identity errors
-      EMAIL: "circleci@localhost"
-      GIT_COMMITTER_NAME: "Circle CI"
-      GIT_AUTHOR_NAME: "Circle CI"
-      EDGE_BUILD_BRANCH: "edge"
-      PLATFORM_REGION: "uk-1.platform.sh"
-      CPPFLAGS: "-DPNG_ARM_NEON_OPT=0"
-      NODE_VERSION: 14.21.3
-    steps:
-      - hosts_keyscan
-      - checkout_code
-      - run:
-          name: Add OS and PHP extensions
-          command: |
-            touch ~/.bashrc
-            curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
-            sudo apt update --allow-releaseinfo-change
-            sudo apt install libjpeg-dev make python3 g++ dh-autoreconf -y
-      - install_psh_cli
-      - run:
-          name: Switch to edge branch
-          command: git checkout -b $EDGE_BUILD_BRANCH
-      - composer_tasks__edge_packages
-      - run:
-          name: Push composer package updates back to GitHub
-          command: |
-            git add composer.*
-            git commit -m "Set dof-dss packages to HEAD development for build"
-      - run:
-          name: Rebuild site themes
-          command: |
-            export NVM_DIR="$HOME/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-            cd $PROJECT_ROOT
-            ./build-themes.sh --sites-dir $PROJECT_ROOT/project/sites
-            # Push to fixed, non-integrating build branch. GitHub webhook integration will propagate this
-            # to platform.sh for later steps to use.
-            cd $PROJECT_ROOT
-            git add *.css
-            git commit -m "Theme rebuild"
-            git push -f origin $EDGE_BUILD_BRANCH
-
-  # Separate task to allow us to sync data on PSH environments, without pauses in other jobs.
-  sync_data:
-    <<: *docker_image
-    steps:
-      - hosts_keyscan
-      - checkout_code
-      - install_psh_cli
-      - run:
-          name: Trigger a data sync from master environment to nightly edge build.
-          command: |
-            platform sync data -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH -y
-          no_output_timeout: 20m
-      - run:
-          name: Backup data sync if the previous attempt failed.
-          command: |
-            # Pause for the blocking activity to finish.
-            sleep 300s
-            platform sync data -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH -y
-          when: on_fail
-          no_output_timeout: 30m
-      - run:
-          name: Run any outstanding updates
-          command: |
-            for site in `ls -l ~/project/project/sites | grep ^d | awk '!/default/{print $9}'`
-            do
-              result=$(platform drush "st -l ${site}" -y -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH | (grep "Drupal bootstrap : Successful" || true) )
-              if [[ -n $result ]]; then
-                result2=$(platform drush "updb -l ${site} -y" -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH | (grep "Fastly (fastly)" || true) )
-            fi
-            done
-          no_output_timeout: 20m
-      - run:
-          name: Turn off fastly module to allow for cleaner config import
-          command: |
-            for site in `ls -l ~/project/project/sites | grep ^d | awk '!/default/{print $9}'`
-            do
-              result=$(platform drush "st -l ${site}" -y -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH | (grep "Drupal bootstrap : Successful" || true) )
-              if [[ -n $result ]]; then
-                result2=$(platform drush "pml --status=enabled -l ${site}" -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH | (grep "Fastly (fastly)" || true) )
-                if [[ -n $result2 ]]; then
-                  echo "***** Uninstall Fastly - ${site} *****"
-                  platform drush "pmu fastly -l ${site}" -y -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH
-                fi
-            fi
-            done
-      - run:
-          name: Clear cache before config import
-          command: |
-            for site in `ls -l ~/project/project/sites | grep ^d | awk '!/default/{print $9}'`
-            do
-              result=$(platform drush "st -l ${site}" -y -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH | (grep "Drupal bootstrap : Successful" || true) )
-              if [[ -n $result ]]; then
-                echo "***** Clear Cache - ${site} *****"
-                platform drush "cr -l ${site}" -y -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH
-              fi
-            done
-      - run:
-          name: Refresh configuration as our db will contain active prod config after sync operation
-          command: |
-            for site in `ls -l ~/project/project/sites | grep ^d | awk '!/default/{print $9}'`
-            do
-              result=$(platform drush "st -l ${site}" -y -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH | (grep "Drupal bootstrap : Successful" || true) )
-              if [[ -n $result ]]; then
-                echo "***** Config Import - ${site} *****"
-                platform drush "cim -l ${site}" -y -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH
-                echo "***** Import blocks/taxonomies/menus - ${site} *****"
-                platform drush "import-all-if-installed safe -l ${site}" -y -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH
-                echo "***** Enable QA accounts - ${site} *****"
-                platform drush "bulk_update_qa_accounts enable -l ${site}" -y -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH
-              fi
-            done
-
-  # Checks to ensure that Unity Base has not been polluted with project files.
-  unity_base_checks:
-    <<: *docker_image
-    steps:
-      - attach_workspace:
-          at: ./
-      - when:
-          condition:
-            equal: [ "https://github.com/dof-dss/unity_base", << pipeline.project.git_url >> ]
-          steps:
-            - run:
-                name: Check Project directory and files do not exist
-                command: |
-                  cd $PROJECT_ROOT
-                  .circleci/unity_base_guardian.sh
+orbs:
+  continuation: circleci/continuation@0.4.0
 
 workflows:
-  version: 2
-  build-test-deploy:
+  setup:
     jobs:
-      - build
-      - unity_base_checks:
-          requires:
-            - build
-      - coding_standards:
-          requires:
-            - build
-      - deprecated_code:
-          requires:
-            - build
-      - disallowed_functions:
-          requires:
-            - build
-      - check_illegal_updates:
-          requires:
-            - build
+      - fetch-and-continue
 
-  # A nightly build of the project, using all dof-dss packages at HEAD from development branch.
-  nightly-edge-build:
-    when:
-      and:
-        - not:
-          equal: [ "https://github.com/dof-dss/unity_base", << pipeline.project.git_url >> ]
-    triggers:
-      - schedule:
-          # At 00:30 Monday to Friday
-          cron: "30 0 * * 1-5"
-          filters:
-            branches:
-              only:
-                - development
-    jobs:
-      - edge_build
-
-  # A nightly deploy or re-deploy of the edge site after the git branch has been created in nightly-edge-build.
-  nightly-edge-build-post-build-tasks:
-    when:
-      and:
-        - not:
-          equal: [ "https://github.com/dof-dss/unity_base", << pipeline.project.git_url >> ]
-    triggers:
-      - schedule:
-          # At 02:55 Monday to Friday
-          cron: "55 2 * * 1-5"
-          filters:
-            branches:
-              only:
-                - edge
-    jobs:
-      - sync_data
+jobs:
+  fetch-and-continue:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run:
+          name: Download shared config
+          command: wget https://raw.githubusercontent.com/dof-dss/webdev-ci/development/shared-config.yml -O shared-config.yml
+      - run:
+          name: Combine shared jobs and local workflows
+          command: |
+            # Remove the 'version: 2.1' from workflows config (since it's in shared config)
+            tail -n +2 .circleci/workflow-config.yml > workflows-only.yml
+            # Concatenate shared jobs+commands with repo workflows
+            cat shared-config.yml workflows-only.yml > full-config.yml
+      - continuation/continue:
+          configuration_path: full-config.yml
+          parameters: |
+            {
+              "php_version": "8.3",
+              "drupal_core_version": "10.4",
+              "node_version": "14.21.3",
+              "coding_standards_dirs": "${PROJECT_ROOT}/web/sites ${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/modules/origins ${PROJECT_ROOT}/web/themes/custom ${PROJECT_ROOT}/web/themes/origins ${PROJECT_ROOT}/web/profiles/unity ${PROJECT_ROOT}/web/profiles/origins",
+              "custom_code_dirs": "${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/themes/custom",
+              "deprecated_code_dirs": "${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/modules/origins",
+              "edge_branch": "edge",
+              "edge_build_dofdss_packages": "dof-dss/nicsdru_unity_theme:dev-10.x-dev dof-dss/nicsdru_origins_modules:dev-10.x-dev dof-dss/nicsdru_unity_modules:dev-10.x-dev dof-dss/nicsdru_unity_profile:dev-10.x-dev",
+              "ssh_fingerprint": "e8:86:75:e8:35:15:07:a6:2d:a0:00:17:69:a1:42:84"
+            }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
             {
               "php_version": "8.3",
               "drupal_core_version": "10.5",
-              "node_version: "18",
+              "node_version": "18",
               "coding_standards_dirs": "${PROJECT_ROOT}/web/sites ${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/modules/origins ${PROJECT_ROOT}/web/themes/custom ${PROJECT_ROOT}/web/themes/origins ${PROJECT_ROOT}/web/profiles/unity ${PROJECT_ROOT}/web/profiles/origins",
               "custom_code_dirs": "${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/themes/custom",
               "deprecated_code_dirs": "${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/modules/origins ${PROJECT_ROOT}/web/themes/custom",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             wget \
               --header="Cache-Control: no-cache" \
               --header="Pragma: no-cache" \
-              "https://raw.githubusercontent.com/dof-dss/webdev-ci/main/shared-config.yml?nocache=$(date +%s)" \
+              "https://raw.githubusercontent.com/dof-dss/webdev-ci/development/shared-config.yml?nocache=$(date +%s)" \
               -O shared-config.yml
 
       - run:
@@ -40,11 +40,11 @@ jobs:
               "php_version": "8.3",
               "drupal_core_version": "10.5",
               "node_version: "18",
-              "coding_standards_dirs": "${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/modules/origins ${PROJECT_ROOT}/web/themes/custom",
-              "custom_code_dirs": "${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/modules/origins",
+              "coding_standards_dirs": "${PROJECT_ROOT}/web/sites ${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/modules/origins ${PROJECT_ROOT}/web/themes/custom ${PROJECT_ROOT}/web/themes/origins ${PROJECT_ROOT}/web/profiles/unity ${PROJECT_ROOT}/web/profiles/origins",
+              "custom_code_dirs": "${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/themes/custom",
               "deprecated_code_dirs": "${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/modules/origins ${PROJECT_ROOT}/web/themes/custom",
               "edge_branch": "edge",
               "edge_build_dofdss_packages": "dof-dss/nicsdru_unity_theme:dev-10.x-dev dof-dss/nicsdru_origins_modules:dev-10.x-dev dof-dss/nicsdru_unity_modules:dev-10.x-dev dof-dss/nicsdru_unity_profile:dev-10.x-dev",
               "ignore_dirs": "/web/themes/origins/node_modules,/web/themes/custom/nicsdru_unity_theme/node_modules",
-              "ssh_fingerprint": "65:4e:c7:ca:9f:c0:40:f7:16:2c:da:33:63:1d:90:12"
+              "ssh_fingerprint": "e8:86:75:e8:35:15:07:a6:2d:a0:00:17:69:a1:42:84"
             }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
           parameters: |
             {
               "php_version": "8.3",
-              "drupal_core_version": "10.4",
+              "drupal_core_version": "10.5",
               "node_version: "18",
               "coding_standards_dirs": "${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/modules/origins ${PROJECT_ROOT}/web/themes/custom",
               "custom_code_dirs": "${PROJECT_ROOT}/web/modules/custom ${PROJECT_ROOT}/web/modules/origins",

--- a/.circleci/workflow-config.yml
+++ b/.circleci/workflow-config.yml
@@ -36,7 +36,7 @@ workflows:
           equal: [ "https://github.com/dof-dss/unity_base", << pipeline.project.git_url >> ]
     triggers:
       - schedule:
-          # At 00:30 Monday to Friday.
+          # At 00:30 Monday to Friday
           cron: "30 0 * * 1-5"
           filters:
             branches:

--- a/.circleci/workflow-config.yml
+++ b/.circleci/workflow-config.yml
@@ -36,7 +36,7 @@ workflows:
           equal: [ "https://github.com/dof-dss/unity_base", << pipeline.project.git_url >> ]
     triggers:
       - schedule:
-          # At 00:30 Monday to Friday
+          # At 00:30 Monday to Friday.
           cron: "30 0 * * 1-5"
           filters:
             branches:

--- a/.circleci/workflow-config.yml
+++ b/.circleci/workflow-config.yml
@@ -35,7 +35,7 @@ workflows:
           equal: [ "https://github.com/dof-dss/unity_base", << pipeline.project.git_url >> ]
     triggers:
       - schedule:
-          # At 00:30 Monday to Friday.
+          # At 00:30 Monday to Friday
           cron: "30 0 * * 1-5"
           filters:
             branches:

--- a/.circleci/workflow-config.yml
+++ b/.circleci/workflow-config.yml
@@ -2,19 +2,24 @@ version: 2.1
 
 workflows:
   build-test:
+    when:
+      and:
+        - not:
+            equal: [ development, << pipeline.git.branch >> ]
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - not:
+            equal: [ api, << pipeline.trigger_source >> ]
     jobs:
       - build:
           php_version: << pipeline.parameters.php_version >>
           ssh_fingerprint: << pipeline.parameters.ssh_fingerprint >>
-      - unity_base_checks:
-          requires:
-            - build
-          php_version: << pipeline.parameters.php_version >>
       - coding_standards:
           requires:
             - build
           php_version: << pipeline.parameters.php_version >>
           coding_standards_dirs: << pipeline.parameters.coding_standards_dirs >>
+          ignore_dirs: << pipeline.parameters.ignore_dirs >>
       - deprecated_code:
           requires:
             - build
@@ -25,44 +30,23 @@ workflows:
             - build
           php_version: << pipeline.parameters.php_version >>
           custom_code_dirs: << pipeline.parameters.custom_code_dirs >>
-      - check_illegal_updates:
-          requires:
-            - build
-          php_version: << pipeline.parameters.php_version >>
   build-edge:
     when:
       and:
-        - not:
-          equal: [ "https://github.com/dof-dss/unity_base", << pipeline.project.git_url >> ]
-    triggers:
-      - schedule:
-          # At 00:30 Monday to Friday
-          cron: "30 0 * * 1-5"
-          filters:
-            branches:
-              only:
-                - development
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ edge_build, << pipeline.schedule.name >> ]
     jobs:
       - unity_edge_build:
-          php_version: << pipeline.parameters.php_version >>
           edge_branch: << pipeline.parameters.edge_branch >>
           edge_build_dofdss_packages: << pipeline.parameters.edge_build_dofdss_packages >>
           node_version: << pipeline.parameters.node_version >>
-  # A separate scheduled workflow to sync the data after the edge build completes.
+          php_version: << pipeline.parameters.php_version >>
   build-edge-finalise:
     when:
       and:
-        - not:
-          equal: [ "https://github.com/dof-dss/unity_base", << pipeline.project.git_url >> ]
-    triggers:
-      - schedule:
-          # At 02:30 on every day-of-week from Monday through Friday
-          cron: "30 2 * * 1-5"
-          filters:
-            branches:
-              only:
-                - DEPT-edge
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ edge_build_finalise, << pipeline.schedule.name >> ]
     jobs:
-      - sync_data:
-          php_version: << pipeline.parameters.php_version >>
+      - unity_sync_data:
           edge_branch: << pipeline.parameters.edge_branch >>
+          php_version: << pipeline.parameters.php_version >>

--- a/.circleci/workflow-config.yml
+++ b/.circleci/workflow-config.yml
@@ -35,7 +35,7 @@ workflows:
           equal: [ "https://github.com/dof-dss/unity_base", << pipeline.project.git_url >> ]
     triggers:
       - schedule:
-          # At 00:30 Monday to Friday
+          # At 00:30 Monday to Friday.
           cron: "30 0 * * 1-5"
           filters:
             branches:

--- a/.circleci/workflow-config.yml
+++ b/.circleci/workflow-config.yml
@@ -28,6 +28,7 @@ workflows:
       - check_illegal_updates:
           requires:
             - build
+          php_version: << pipeline.parameters.php_version >>
   build-edge:
     when:
       and:

--- a/.circleci/workflow-config.yml
+++ b/.circleci/workflow-config.yml
@@ -1,0 +1,67 @@
+version: 2.1
+
+workflows:
+  build-test:
+    jobs:
+      - build:
+          php_version: << pipeline.parameters.php_version >>
+          ssh_fingerprint: << pipeline.parameters.ssh_fingerprint >>
+      - unity_base_checks:
+          requires:
+            - build
+          php_version: << pipeline.parameters.php_version >>
+      - coding_standards:
+          requires:
+            - build
+          php_version: << pipeline.parameters.php_version >>
+          coding_standards_dirs: << pipeline.parameters.coding_standards_dirs >>
+      - deprecated_code:
+          requires:
+            - build
+          php_version: << pipeline.parameters.php_version >>
+          deprecated_code_dirs: << pipeline.parameters.deprecated_code_dirs >>
+      - disallowed_functions:
+          requires:
+            - build
+          php_version: << pipeline.parameters.php_version >>
+          custom_code_dirs: << pipeline.parameters.custom_code_dirs >>
+      - check_illegal_updates:
+          requires:
+            - build
+  build-edge:
+    when:
+      and:
+        - not:
+          equal: [ "https://github.com/dof-dss/unity_base", << pipeline.project.git_url >> ]
+    triggers:
+      - schedule:
+          # At 00:30 Monday to Friday
+          cron: "30 0 * * 1-5"
+          filters:
+            branches:
+              only:
+                - development
+    jobs:
+      - build_edge:
+          php_version: << pipeline.parameters.php_version >>
+          edge_branch: << pipeline.parameters.edge_branch >>
+          edge_build_dofdss_packages: << pipeline.parameters.edge_build_dofdss_packages >>
+          node_version: << pipeline.parameters.node_version >>
+  # A separate scheduled workflow to sync the data after the edge build completes.
+  build-edge-finalise:
+    when:
+      and:
+        - not:
+          equal: [ "https://github.com/dof-dss/unity_base", << pipeline.project.git_url >> ]
+    triggers:
+      - schedule:
+          # At 02:30 on every day-of-week from Monday through Friday
+          cron: "30 2 * * 1-5"
+          filters:
+            branches:
+              only:
+                - DEPT-edge
+    jobs:
+      - sync_data:
+          php_version: << pipeline.parameters.php_version >>
+          edge_branch: << pipeline.parameters.edge_branch >>

--- a/.circleci/workflow-config.yml
+++ b/.circleci/workflow-config.yml
@@ -42,7 +42,7 @@ workflows:
               only:
                 - development
     jobs:
-      - build_edge:
+      - unity_edge_build:
           php_version: << pipeline.parameters.php_version >>
           edge_branch: << pipeline.parameters.edge_branch >>
           edge_build_dofdss_packages: << pipeline.parameters.edge_build_dofdss_packages >>

--- a/.ddev/commands/web/phpcs
+++ b/.ddev/commands/web/phpcs
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
 
-## Description: Execute local PHPCS static analysis checks in the current directory and non contrib modules and themes.
-## Usage: phpcs
-## Example: "ddev phpcs"
+## Description: Execute local PHPCS static analysis checks.
+## Usage: phpcs [directory]
+## Example: "ddev phpcs" or "ddev phpcs web/modules/custom"
 ## HostWorkingDir: true
 
-/var/www/html/phpcs.sh ./ "/var/www/html" "/var/www/html/web/modules/origins /var/www/html/web/modules/custom /var/www/html/web/themes/custom"
+DRUPAL_DEPLOY_PATH="/var/www/html"
+IGNORE="/web/themes/origins/node_modules,/web/themes/custom/nicsdru_unity_theme/node_modules"
+
+# If an argument is provided, use it; otherwise, use the current working directory
+if [ -n "$1" ]; then
+  PHPCS_CHECK_DIR="$1"
+else
+  PHPCS_CHECK_DIR="."
+fi
+
+${DRUPAL_DEPLOY_PATH}/phpcs.sh "${DRUPAL_DEPLOY_PATH}" "${PHPCS_CHECK_DIR}" "${IGNORE}"

--- a/phpcs.sh
+++ b/phpcs.sh
@@ -1,8 +1,37 @@
 #!/usr/bin/env bash
 
+# Require all arguments
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 <DRUPAL_DEPLOY_PATH> <PHPCS_CHECK_DIR> <IGNORE>"
+  echo "  DRUPAL_DEPLOY_PATH: Path to Drupal deployment (e.g., /var/www/deploy)"
+  echo "  PHPCS_CHECK_DIR: Directory to check (e.g., web/modules/custom)"
+  echo "  IGNORE: Comma-separated directories to ignore, relative to DRUPAL_DEPLOY_PATH or absolute (e.g., web/themes/custom/mytheme/node_modules,web/modules/custom/my_module/tests)"
+  exit 1
+fi
+
 DRUPAL_DEPLOY_PATH=$1
-# We only care about our custom code folder and custom theme folder.
 PHPCS_CHECK_DIR=$2
+IGNORE=$3
+
+# Split IGNORE into array, prepend DRUPAL_DEPLOY_PATH to each if not absolute, then join back.
+IFS=',' read -ra IGNORE_ITEMS <<< "$IGNORE"
+IGNORE_PATHS=""
+for item in "${IGNORE_ITEMS[@]}"; do
+    # Trim whitespace
+    trimmed=$(echo "$item" | xargs)
+    # If path is not absolute, prepend DRUPAL_DEPLOY_PATH
+    if [[ "$trimmed" = /* ]]; then
+        fullpath="$trimmed"
+    else
+        fullpath="${DRUPAL_DEPLOY_PATH}/${trimmed}"
+    fi
+    # Comma separate, no trailing comma
+    if [ -z "$IGNORE_PATHS" ]; then
+        IGNORE_PATHS="$fullpath"
+    else
+        IGNORE_PATHS="$IGNORE_PATHS,$fullpath"
+    fi
+done
 
 # Dependencies are added with composer. Shouldn't be using a global install even if available.
 PHPCS_PATH="${DRUPAL_DEPLOY_PATH}/vendor/bin/phpcs"
@@ -21,11 +50,10 @@ DRUPAL_PRACTICE_EXCLUDED_SNIFFS=(
   DrupalPractice.Objects.StrictSchemaDisabled
 )
 
-# Comma separated list of npm or non-PHP related FE toolchain directories we want to ignore.
-IGNORE="${DRUPAL_DEPLOY_PATH}/web/themes/custom/nicsdru_unity_theme/node_modules,${DRUPAL_DEPLOY_PATH}/web/modules/custom/node_modules,${DRUPAL_DEPLOY_PATH}/web/themes/origins/node_modules"
-
-echo "Running coding standard checks in ${PHPCS_CHECK_DIR}"
-echo "Ignoring directories: ${IGNORE}"
+echo "----------------------------------------------------------------------"
+echo ">>> Running coding standard checks in: ${PHPCS_CHECK_DIR}"
+echo ">>> Ignoring directories: ${IGNORE}"
+echo "----------------------------------------------------------------------"
 
 # Configure PHPCS.
 ${PHPCS_PATH} --config-set installed_paths ${DRUPAL_DEPLOY_PATH}/vendor/drupal/coder/coder_sniffer,${DRUPAL_DEPLOY_PATH}/vendor/slevomat/coding-standard
@@ -34,6 +62,7 @@ EXCLUDE=$(IFS=, ; echo "${DRUPAL_EXCLUDED_SNIFFS[*]}")
 ${PHPCS_PATH} -nq --standard=Drupal --extensions=${PHPCS_EXTENSIONS} --exclude=${EXCLUDE} --ignore=${IGNORE} ${PHPCS_CHECK_DIR}
 if [ $? != 0 ]
 then
+    echo "🚫 Drupal coding standards checks failed, see above for details 🚫"
     exit 1
 fi
 
@@ -42,5 +71,9 @@ EXCLUDE=$(IFS=, ; echo "${DRUPAL_PRACTICE_EXCLUDED_SNIFFS[*]}")
 ${PHPCS_PATH} -nq --standard=DrupalPractice --extensions=${PHPCS_EXTENSIONS} --exclude=${EXCLUDE} --ignore=${IGNORE} ${PHPCS_CHECK_DIR}
 if [ $? != 0 ]
 then
+    echo "🚫 Drupal best practice checks failed, see above for details 🚫"
     exit 1
 fi
+
+## Make it clearer when the script succeeds.
+echo "LGTM ✅"


### PR DESCRIPTION
# Summary: 

- Bulk of jobs/commands now sourced from https://github.com/dof-dss/webdev-ci/blob/development/shared-config.yml for re-use across Unity repos.
- Workflows for this project defined under `.circleci/workflow-config.yml `
- CI setup and continue tasks (via orbs) defined in `.circleci/config.yml`

Job names have changed (a bit) so a repo admin will need to amend branch protection rules to unselect the old and select the new CI job names required to permit a PR to merge.