### PR TITLE
Make sure Solr data directory exists at startup

### DIFF
--- a/.ddev/solr/create-or-refresh-cores.sh
+++ b/.ddev/solr/create-or-refresh-cores.sh
@@ -2,6 +2,8 @@
 #ddev-generated
 set -euo pipefail
 
+mkdir -p /var/solr/data
+
 # DDEV Solr is intentionally unauthenticated. Remove any security policy left
 # in the disposable local volume by an earlier authenticated configuration.
 rm -f /var/solr/data/security.json


### PR DESCRIPTION
Replicates dof-dss/corp-lite@46951a293838d57e00200ade908d8f0ff20cdd63.\n\nCreates /var/solr/data before removing a stale security.json file, so the startup script also works with a fresh Solr data volume.\n\nVerification:\n- bash -n .ddev/solr/create-or-refresh-cores.sh\n- git diff --check